### PR TITLE
support bigint denoms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@commander-js/extra-typings": "^11.1.0",
         "@cosmjs/cosmwasm-stargate": "^0.31.3",
-        "@cosmjs/stargate": "^0.29.3",
+        "@cosmjs/stargate": "^0.31.3",
         "chalk": "^4.0.0",
         "cosmjs-types": "^0.5.2",
         "fireblocks-sdk": "^4.0.0",
@@ -66,14 +66,14 @@
       }
     },
     "node_modules/@cosmjs/amino": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.29.5.tgz",
-      "integrity": "sha512-Qo8jpC0BiziTSUqpkNatBcwtKNhCovUnFul9SlT/74JUCdLYaeG5hxr3q1cssQt++l4LvlcpF+OUXL48XjNjLw==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.31.3.tgz",
+      "integrity": "sha512-36emtUq895sPRX8PTSOnG+lhJDCVyIcE0Tr5ct59sUbgQiI14y43vj/4WAlJ/utSOxy+Zhj9wxcs4AZfu0BHsw==",
       "dependencies": {
-        "@cosmjs/crypto": "^0.29.5",
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5"
+        "@cosmjs/crypto": "^0.31.3",
+        "@cosmjs/encoding": "^0.31.3",
+        "@cosmjs/math": "^0.31.3",
+        "@cosmjs/utils": "^0.31.3"
       }
     },
     "node_modules/@cosmjs/cosmwasm-stargate": {
@@ -94,18 +94,16 @@
         "pako": "^2.0.2"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/amino": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.31.3.tgz",
-      "integrity": "sha512-36emtUq895sPRX8PTSOnG+lhJDCVyIcE0Tr5ct59sUbgQiI14y43vj/4WAlJ/utSOxy+Zhj9wxcs4AZfu0BHsw==",
+    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/cosmjs-types": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.8.0.tgz",
+      "integrity": "sha512-Q2Mj95Fl0PYMWEhA2LuGEIhipF7mQwd9gTQ85DdP9jjjopeoGaDxvmPa5nakNzsq7FnO1DMTatXTAx6bxMH7Lg==",
       "dependencies": {
-        "@cosmjs/crypto": "^0.31.3",
-        "@cosmjs/encoding": "^0.31.3",
-        "@cosmjs/math": "^0.31.3",
-        "@cosmjs/utils": "^0.31.3"
+        "long": "^4.0.0",
+        "protobufjs": "~6.11.2"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/crypto": {
+    "node_modules/@cosmjs/crypto": {
       "version": "0.31.3",
       "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.31.3.tgz",
       "integrity": "sha512-vRbvM9ZKR2017TO73dtJ50KxoGcFzKtKI7C8iO302BQ5p+DuB+AirUg1952UpSoLfv5ki9O416MFANNg8UN/EQ==",
@@ -119,7 +117,7 @@
         "libsodium-wrappers-sumo": "^0.7.11"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/encoding": {
+    "node_modules/@cosmjs/encoding": {
       "version": "0.31.3",
       "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.31.3.tgz",
       "integrity": "sha512-6IRtG0fiVYwyP7n+8e54uTx2pLYijO48V3t9TLiROERm5aUAIzIlz6Wp0NYaI5he9nh1lcEGJ1lkquVKFw3sUg==",
@@ -129,7 +127,7 @@
         "readonly-date": "^1.0.0"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/json-rpc": {
+    "node_modules/@cosmjs/json-rpc": {
       "version": "0.31.3",
       "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.31.3.tgz",
       "integrity": "sha512-7LVYerXjnm69qqYR3uA6LGCrBW2EO5/F7lfJxAmY+iII2C7xO3a0vAjMSt5zBBh29PXrJVS6c2qRP22W1Le2Wg==",
@@ -138,7 +136,7 @@
         "xstream": "^11.14.0"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/math": {
+    "node_modules/@cosmjs/math": {
       "version": "0.31.3",
       "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.31.3.tgz",
       "integrity": "sha512-kZ2C6glA5HDb9hLz1WrftAjqdTBb3fWQsRR+Us2HsjAYdeE6M3VdXMsYCP5M3yiihal1WDwAY2U7HmfJw7Uh4A==",
@@ -146,7 +144,7 @@
         "bn.js": "^5.2.0"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/proto-signing": {
+    "node_modules/@cosmjs/proto-signing": {
       "version": "0.31.3",
       "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.31.3.tgz",
       "integrity": "sha512-24+10/cGl6lLS4VCrGTCJeDRPQTn1K5JfknzXzDIHOx8THR31JxA7/HV5eWGHqWgAbudA7ccdSvEK08lEHHtLA==",
@@ -160,7 +158,16 @@
         "long": "^4.0.0"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/socket": {
+    "node_modules/@cosmjs/proto-signing/node_modules/cosmjs-types": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.8.0.tgz",
+      "integrity": "sha512-Q2Mj95Fl0PYMWEhA2LuGEIhipF7mQwd9gTQ85DdP9jjjopeoGaDxvmPa5nakNzsq7FnO1DMTatXTAx6bxMH7Lg==",
+      "dependencies": {
+        "long": "^4.0.0",
+        "protobufjs": "~6.11.2"
+      }
+    },
+    "node_modules/@cosmjs/socket": {
       "version": "0.31.3",
       "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.31.3.tgz",
       "integrity": "sha512-aqrDGGi7os/hsz5p++avI4L0ZushJ+ItnzbqA7C6hamFSCJwgOkXaOUs+K9hXZdX4rhY7rXO4PH9IH8q09JkTw==",
@@ -171,7 +178,7 @@
         "xstream": "^11.14.0"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/stargate": {
+    "node_modules/@cosmjs/stargate": {
       "version": "0.31.3",
       "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.31.3.tgz",
       "integrity": "sha512-53NxnzmB9FfXpG4KjOUAYAvWLYKdEmZKsutcat/u2BrDXNZ7BN8jim/ENcpwXfs9/Og0K24lEIdvA4gsq3JDQw==",
@@ -190,7 +197,16 @@
         "xstream": "^11.14.0"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/stream": {
+    "node_modules/@cosmjs/stargate/node_modules/cosmjs-types": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.8.0.tgz",
+      "integrity": "sha512-Q2Mj95Fl0PYMWEhA2LuGEIhipF7mQwd9gTQ85DdP9jjjopeoGaDxvmPa5nakNzsq7FnO1DMTatXTAx6bxMH7Lg==",
+      "dependencies": {
+        "long": "^4.0.0",
+        "protobufjs": "~6.11.2"
+      }
+    },
+    "node_modules/@cosmjs/stream": {
       "version": "0.31.3",
       "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.31.3.tgz",
       "integrity": "sha512-8keYyI7X0RjsLyVcZuBeNjSv5FA4IHwbFKx7H60NHFXszN8/MvXL6aZbNIvxtcIHHsW7K9QSQos26eoEWlAd+w==",
@@ -198,7 +214,7 @@
         "xstream": "^11.14.0"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/tendermint-rpc": {
+    "node_modules/@cosmjs/tendermint-rpc": {
       "version": "0.31.3",
       "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.31.3.tgz",
       "integrity": "sha512-s3TiWkPCW4QceTQjpYqn4xttUJH36mTPqplMl+qyocdqk5+X5mergzExU/pHZRWQ4pbby8bnR7kMvG4OC1aZ8g==",
@@ -215,134 +231,10 @@
         "xstream": "^11.14.0"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/utils": {
+    "node_modules/@cosmjs/utils": {
       "version": "0.31.3",
       "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.31.3.tgz",
       "integrity": "sha512-VBhAgzrrYdIe0O5IbKRqwszbQa7ZyQLx9nEQuHQ3HUplQW7P44COG/ye2n6AzCudtqxmwdX7nyX8ta1J07GoqA=="
-    },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/cosmjs-types": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.8.0.tgz",
-      "integrity": "sha512-Q2Mj95Fl0PYMWEhA2LuGEIhipF7mQwd9gTQ85DdP9jjjopeoGaDxvmPa5nakNzsq7FnO1DMTatXTAx6bxMH7Lg==",
-      "dependencies": {
-        "long": "^4.0.0",
-        "protobufjs": "~6.11.2"
-      }
-    },
-    "node_modules/@cosmjs/crypto": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.5.tgz",
-      "integrity": "sha512-2bKkaLGictaNL0UipQCL6C1afaisv6k8Wr/GCLx9FqiyFkh9ZgRHDyetD64ZsjnWV/N/D44s/esI+k6oPREaiQ==",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
-        "libsodium-wrappers": "^0.7.6"
-      }
-    },
-    "node_modules/@cosmjs/encoding": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.5.tgz",
-      "integrity": "sha512-G4rGl/Jg4dMCw5u6PEZHZcoHnUBlukZODHbm/wcL4Uu91fkn5jVo5cXXZcvs4VCkArVGrEj/52eUgTZCmOBGWQ==",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@cosmjs/json-rpc": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.29.5.tgz",
-      "integrity": "sha512-C78+X06l+r9xwdM1yFWIpGl03LhB9NdM1xvZpQHwgCOl0Ir/WV8pw48y3Ez2awAoUBRfTeejPe4KvrE6NoIi/w==",
-      "dependencies": {
-        "@cosmjs/stream": "^0.29.5",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@cosmjs/math": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.5.tgz",
-      "integrity": "sha512-2GjKcv+A9f86MAWYLUkjhw1/WpRl2R1BTb3m9qPG7lzMA7ioYff9jY5SPCfafKdxM4TIQGxXQlYGewQL16O68Q==",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
-    "node_modules/@cosmjs/proto-signing": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.29.5.tgz",
-      "integrity": "sha512-QRrS7CiKaoETdgIqvi/7JC2qCwCR7lnWaUsTzh/XfRy3McLkEd+cXbKAW3cygykv7IN0VAEIhZd2lyIfT8KwNA==",
-      "dependencies": {
-        "@cosmjs/amino": "^0.29.5",
-        "@cosmjs/crypto": "^0.29.5",
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5",
-        "cosmjs-types": "^0.5.2",
-        "long": "^4.0.0"
-      }
-    },
-    "node_modules/@cosmjs/socket": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.29.5.tgz",
-      "integrity": "sha512-5VYDupIWbIXq3ftPV1LkS5Ya/T7Ol/AzWVhNxZ79hPe/mBfv1bGau/LqIYOm2zxGlgm9hBHOTmWGqNYDwr9LNQ==",
-      "dependencies": {
-        "@cosmjs/stream": "^0.29.5",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@cosmjs/stargate": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.29.5.tgz",
-      "integrity": "sha512-hjEv8UUlJruLrYGJcUZXM/CziaINOKwfVm2BoSdUnNTMxGvY/jC1ABHKeZUYt9oXHxEJ1n9+pDqzbKc8pT0nBw==",
-      "dependencies": {
-        "@confio/ics23": "^0.6.8",
-        "@cosmjs/amino": "^0.29.5",
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/proto-signing": "^0.29.5",
-        "@cosmjs/stream": "^0.29.5",
-        "@cosmjs/tendermint-rpc": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5",
-        "cosmjs-types": "^0.5.2",
-        "long": "^4.0.0",
-        "protobufjs": "~6.11.3",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@cosmjs/stream": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.29.5.tgz",
-      "integrity": "sha512-TToTDWyH1p05GBtF0Y8jFw2C+4783ueDCmDyxOMM6EU82IqpmIbfwcdMOCAm0JhnyMh+ocdebbFvnX/sGKzRAA==",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.29.5.tgz",
-      "integrity": "sha512-ar80twieuAxsy0x2za/aO3kBr2DFPAXDmk2ikDbmkda+qqfXgl35l9CVAAjKRqd9d+cRvbQyb5M4wy6XQpEV6w==",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.29.5",
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/json-rpc": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/socket": "^0.29.5",
-        "@cosmjs/stream": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5",
-        "axios": "^0.21.2",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@cosmjs/utils": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.5.tgz",
-      "integrity": "sha512-m7h+RXDUxOzEOGt4P+3OVPX7PuakZT3GBmaM/Y2u+abN3xZkziykD/NvedYFvvCCdQo714XcGl33bwifS9FZPQ=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -2670,23 +2562,10 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/libsodium": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.13.tgz",
-      "integrity": "sha512-mK8ju0fnrKXXfleL53vtp9xiPq5hKM0zbDQtcxQIsSmxNgSxqCj6R7Hl9PkrNe2j29T4yoDaF7DJLK9/i5iWUw=="
-    },
     "node_modules/libsodium-sumo": {
       "version": "0.7.13",
       "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.13.tgz",
       "integrity": "sha512-zTGdLu4b9zSNLfovImpBCbdAA4xkpkZbMnSQjP8HShyOutnGjRHmSOKlsylh1okao6QhLiz7nG98EGn+04cZjQ=="
-    },
-    "node_modules/libsodium-wrappers": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.13.tgz",
-      "integrity": "sha512-kasvDsEi/r1fMzKouIDv7B8I6vNmknXwGiYodErGuESoFTohGSKZplFtVxZqHaoQ217AynyIFgnOVRitpHs0Qw==",
-      "dependencies": {
-        "libsodium": "^0.7.13"
-      }
     },
     "node_modules/libsodium-wrappers-sumo": {
       "version": "0.7.13",
@@ -3861,14 +3740,14 @@
       }
     },
     "@cosmjs/amino": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.29.5.tgz",
-      "integrity": "sha512-Qo8jpC0BiziTSUqpkNatBcwtKNhCovUnFul9SlT/74JUCdLYaeG5hxr3q1cssQt++l4LvlcpF+OUXL48XjNjLw==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.31.3.tgz",
+      "integrity": "sha512-36emtUq895sPRX8PTSOnG+lhJDCVyIcE0Tr5ct59sUbgQiI14y43vj/4WAlJ/utSOxy+Zhj9wxcs4AZfu0BHsw==",
       "requires": {
-        "@cosmjs/crypto": "^0.29.5",
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5"
+        "@cosmjs/crypto": "^0.31.3",
+        "@cosmjs/encoding": "^0.31.3",
+        "@cosmjs/math": "^0.31.3",
+        "@cosmjs/utils": "^0.31.3"
       }
     },
     "@cosmjs/cosmwasm-stargate": {
@@ -3889,132 +3768,6 @@
         "pako": "^2.0.2"
       },
       "dependencies": {
-        "@cosmjs/amino": {
-          "version": "0.31.3",
-          "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.31.3.tgz",
-          "integrity": "sha512-36emtUq895sPRX8PTSOnG+lhJDCVyIcE0Tr5ct59sUbgQiI14y43vj/4WAlJ/utSOxy+Zhj9wxcs4AZfu0BHsw==",
-          "requires": {
-            "@cosmjs/crypto": "^0.31.3",
-            "@cosmjs/encoding": "^0.31.3",
-            "@cosmjs/math": "^0.31.3",
-            "@cosmjs/utils": "^0.31.3"
-          }
-        },
-        "@cosmjs/crypto": {
-          "version": "0.31.3",
-          "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.31.3.tgz",
-          "integrity": "sha512-vRbvM9ZKR2017TO73dtJ50KxoGcFzKtKI7C8iO302BQ5p+DuB+AirUg1952UpSoLfv5ki9O416MFANNg8UN/EQ==",
-          "requires": {
-            "@cosmjs/encoding": "^0.31.3",
-            "@cosmjs/math": "^0.31.3",
-            "@cosmjs/utils": "^0.31.3",
-            "@noble/hashes": "^1",
-            "bn.js": "^5.2.0",
-            "elliptic": "^6.5.4",
-            "libsodium-wrappers-sumo": "^0.7.11"
-          }
-        },
-        "@cosmjs/encoding": {
-          "version": "0.31.3",
-          "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.31.3.tgz",
-          "integrity": "sha512-6IRtG0fiVYwyP7n+8e54uTx2pLYijO48V3t9TLiROERm5aUAIzIlz6Wp0NYaI5he9nh1lcEGJ1lkquVKFw3sUg==",
-          "requires": {
-            "base64-js": "^1.3.0",
-            "bech32": "^1.1.4",
-            "readonly-date": "^1.0.0"
-          }
-        },
-        "@cosmjs/json-rpc": {
-          "version": "0.31.3",
-          "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.31.3.tgz",
-          "integrity": "sha512-7LVYerXjnm69qqYR3uA6LGCrBW2EO5/F7lfJxAmY+iII2C7xO3a0vAjMSt5zBBh29PXrJVS6c2qRP22W1Le2Wg==",
-          "requires": {
-            "@cosmjs/stream": "^0.31.3",
-            "xstream": "^11.14.0"
-          }
-        },
-        "@cosmjs/math": {
-          "version": "0.31.3",
-          "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.31.3.tgz",
-          "integrity": "sha512-kZ2C6glA5HDb9hLz1WrftAjqdTBb3fWQsRR+Us2HsjAYdeE6M3VdXMsYCP5M3yiihal1WDwAY2U7HmfJw7Uh4A==",
-          "requires": {
-            "bn.js": "^5.2.0"
-          }
-        },
-        "@cosmjs/proto-signing": {
-          "version": "0.31.3",
-          "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.31.3.tgz",
-          "integrity": "sha512-24+10/cGl6lLS4VCrGTCJeDRPQTn1K5JfknzXzDIHOx8THR31JxA7/HV5eWGHqWgAbudA7ccdSvEK08lEHHtLA==",
-          "requires": {
-            "@cosmjs/amino": "^0.31.3",
-            "@cosmjs/crypto": "^0.31.3",
-            "@cosmjs/encoding": "^0.31.3",
-            "@cosmjs/math": "^0.31.3",
-            "@cosmjs/utils": "^0.31.3",
-            "cosmjs-types": "^0.8.0",
-            "long": "^4.0.0"
-          }
-        },
-        "@cosmjs/socket": {
-          "version": "0.31.3",
-          "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.31.3.tgz",
-          "integrity": "sha512-aqrDGGi7os/hsz5p++avI4L0ZushJ+ItnzbqA7C6hamFSCJwgOkXaOUs+K9hXZdX4rhY7rXO4PH9IH8q09JkTw==",
-          "requires": {
-            "@cosmjs/stream": "^0.31.3",
-            "isomorphic-ws": "^4.0.1",
-            "ws": "^7",
-            "xstream": "^11.14.0"
-          }
-        },
-        "@cosmjs/stargate": {
-          "version": "0.31.3",
-          "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.31.3.tgz",
-          "integrity": "sha512-53NxnzmB9FfXpG4KjOUAYAvWLYKdEmZKsutcat/u2BrDXNZ7BN8jim/ENcpwXfs9/Og0K24lEIdvA4gsq3JDQw==",
-          "requires": {
-            "@confio/ics23": "^0.6.8",
-            "@cosmjs/amino": "^0.31.3",
-            "@cosmjs/encoding": "^0.31.3",
-            "@cosmjs/math": "^0.31.3",
-            "@cosmjs/proto-signing": "^0.31.3",
-            "@cosmjs/stream": "^0.31.3",
-            "@cosmjs/tendermint-rpc": "^0.31.3",
-            "@cosmjs/utils": "^0.31.3",
-            "cosmjs-types": "^0.8.0",
-            "long": "^4.0.0",
-            "protobufjs": "~6.11.3",
-            "xstream": "^11.14.0"
-          }
-        },
-        "@cosmjs/stream": {
-          "version": "0.31.3",
-          "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.31.3.tgz",
-          "integrity": "sha512-8keYyI7X0RjsLyVcZuBeNjSv5FA4IHwbFKx7H60NHFXszN8/MvXL6aZbNIvxtcIHHsW7K9QSQos26eoEWlAd+w==",
-          "requires": {
-            "xstream": "^11.14.0"
-          }
-        },
-        "@cosmjs/tendermint-rpc": {
-          "version": "0.31.3",
-          "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.31.3.tgz",
-          "integrity": "sha512-s3TiWkPCW4QceTQjpYqn4xttUJH36mTPqplMl+qyocdqk5+X5mergzExU/pHZRWQ4pbby8bnR7kMvG4OC1aZ8g==",
-          "requires": {
-            "@cosmjs/crypto": "^0.31.3",
-            "@cosmjs/encoding": "^0.31.3",
-            "@cosmjs/json-rpc": "^0.31.3",
-            "@cosmjs/math": "^0.31.3",
-            "@cosmjs/socket": "^0.31.3",
-            "@cosmjs/stream": "^0.31.3",
-            "@cosmjs/utils": "^0.31.3",
-            "axios": "^0.21.2",
-            "readonly-date": "^1.0.0",
-            "xstream": "^11.14.0"
-          }
-        },
-        "@cosmjs/utils": {
-          "version": "0.31.3",
-          "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.31.3.tgz",
-          "integrity": "sha512-VBhAgzrrYdIe0O5IbKRqwszbQa7ZyQLx9nEQuHQ3HUplQW7P44COG/ye2n6AzCudtqxmwdX7nyX8ta1J07GoqA=="
-        },
         "cosmjs-types": {
           "version": "0.8.0",
           "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.8.0.tgz",
@@ -4027,23 +3780,23 @@
       }
     },
     "@cosmjs/crypto": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.29.5.tgz",
-      "integrity": "sha512-2bKkaLGictaNL0UipQCL6C1afaisv6k8Wr/GCLx9FqiyFkh9ZgRHDyetD64ZsjnWV/N/D44s/esI+k6oPREaiQ==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.31.3.tgz",
+      "integrity": "sha512-vRbvM9ZKR2017TO73dtJ50KxoGcFzKtKI7C8iO302BQ5p+DuB+AirUg1952UpSoLfv5ki9O416MFANNg8UN/EQ==",
       "requires": {
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5",
+        "@cosmjs/encoding": "^0.31.3",
+        "@cosmjs/math": "^0.31.3",
+        "@cosmjs/utils": "^0.31.3",
         "@noble/hashes": "^1",
         "bn.js": "^5.2.0",
         "elliptic": "^6.5.4",
-        "libsodium-wrappers": "^0.7.6"
+        "libsodium-wrappers-sumo": "^0.7.11"
       }
     },
     "@cosmjs/encoding": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.29.5.tgz",
-      "integrity": "sha512-G4rGl/Jg4dMCw5u6PEZHZcoHnUBlukZODHbm/wcL4Uu91fkn5jVo5cXXZcvs4VCkArVGrEj/52eUgTZCmOBGWQ==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.31.3.tgz",
+      "integrity": "sha512-6IRtG0fiVYwyP7n+8e54uTx2pLYijO48V3t9TLiROERm5aUAIzIlz6Wp0NYaI5he9nh1lcEGJ1lkquVKFw3sUg==",
       "requires": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
@@ -4051,95 +3804,117 @@
       }
     },
     "@cosmjs/json-rpc": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.29.5.tgz",
-      "integrity": "sha512-C78+X06l+r9xwdM1yFWIpGl03LhB9NdM1xvZpQHwgCOl0Ir/WV8pw48y3Ez2awAoUBRfTeejPe4KvrE6NoIi/w==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.31.3.tgz",
+      "integrity": "sha512-7LVYerXjnm69qqYR3uA6LGCrBW2EO5/F7lfJxAmY+iII2C7xO3a0vAjMSt5zBBh29PXrJVS6c2qRP22W1Le2Wg==",
       "requires": {
-        "@cosmjs/stream": "^0.29.5",
+        "@cosmjs/stream": "^0.31.3",
         "xstream": "^11.14.0"
       }
     },
     "@cosmjs/math": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.29.5.tgz",
-      "integrity": "sha512-2GjKcv+A9f86MAWYLUkjhw1/WpRl2R1BTb3m9qPG7lzMA7ioYff9jY5SPCfafKdxM4TIQGxXQlYGewQL16O68Q==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.31.3.tgz",
+      "integrity": "sha512-kZ2C6glA5HDb9hLz1WrftAjqdTBb3fWQsRR+Us2HsjAYdeE6M3VdXMsYCP5M3yiihal1WDwAY2U7HmfJw7Uh4A==",
       "requires": {
         "bn.js": "^5.2.0"
       }
     },
     "@cosmjs/proto-signing": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.29.5.tgz",
-      "integrity": "sha512-QRrS7CiKaoETdgIqvi/7JC2qCwCR7lnWaUsTzh/XfRy3McLkEd+cXbKAW3cygykv7IN0VAEIhZd2lyIfT8KwNA==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.31.3.tgz",
+      "integrity": "sha512-24+10/cGl6lLS4VCrGTCJeDRPQTn1K5JfknzXzDIHOx8THR31JxA7/HV5eWGHqWgAbudA7ccdSvEK08lEHHtLA==",
       "requires": {
-        "@cosmjs/amino": "^0.29.5",
-        "@cosmjs/crypto": "^0.29.5",
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5",
-        "cosmjs-types": "^0.5.2",
+        "@cosmjs/amino": "^0.31.3",
+        "@cosmjs/crypto": "^0.31.3",
+        "@cosmjs/encoding": "^0.31.3",
+        "@cosmjs/math": "^0.31.3",
+        "@cosmjs/utils": "^0.31.3",
+        "cosmjs-types": "^0.8.0",
         "long": "^4.0.0"
+      },
+      "dependencies": {
+        "cosmjs-types": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.8.0.tgz",
+          "integrity": "sha512-Q2Mj95Fl0PYMWEhA2LuGEIhipF7mQwd9gTQ85DdP9jjjopeoGaDxvmPa5nakNzsq7FnO1DMTatXTAx6bxMH7Lg==",
+          "requires": {
+            "long": "^4.0.0",
+            "protobufjs": "~6.11.2"
+          }
+        }
       }
     },
     "@cosmjs/socket": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.29.5.tgz",
-      "integrity": "sha512-5VYDupIWbIXq3ftPV1LkS5Ya/T7Ol/AzWVhNxZ79hPe/mBfv1bGau/LqIYOm2zxGlgm9hBHOTmWGqNYDwr9LNQ==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.31.3.tgz",
+      "integrity": "sha512-aqrDGGi7os/hsz5p++avI4L0ZushJ+ItnzbqA7C6hamFSCJwgOkXaOUs+K9hXZdX4rhY7rXO4PH9IH8q09JkTw==",
       "requires": {
-        "@cosmjs/stream": "^0.29.5",
+        "@cosmjs/stream": "^0.31.3",
         "isomorphic-ws": "^4.0.1",
         "ws": "^7",
         "xstream": "^11.14.0"
       }
     },
     "@cosmjs/stargate": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.29.5.tgz",
-      "integrity": "sha512-hjEv8UUlJruLrYGJcUZXM/CziaINOKwfVm2BoSdUnNTMxGvY/jC1ABHKeZUYt9oXHxEJ1n9+pDqzbKc8pT0nBw==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.31.3.tgz",
+      "integrity": "sha512-53NxnzmB9FfXpG4KjOUAYAvWLYKdEmZKsutcat/u2BrDXNZ7BN8jim/ENcpwXfs9/Og0K24lEIdvA4gsq3JDQw==",
       "requires": {
         "@confio/ics23": "^0.6.8",
-        "@cosmjs/amino": "^0.29.5",
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/proto-signing": "^0.29.5",
-        "@cosmjs/stream": "^0.29.5",
-        "@cosmjs/tendermint-rpc": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5",
-        "cosmjs-types": "^0.5.2",
+        "@cosmjs/amino": "^0.31.3",
+        "@cosmjs/encoding": "^0.31.3",
+        "@cosmjs/math": "^0.31.3",
+        "@cosmjs/proto-signing": "^0.31.3",
+        "@cosmjs/stream": "^0.31.3",
+        "@cosmjs/tendermint-rpc": "^0.31.3",
+        "@cosmjs/utils": "^0.31.3",
+        "cosmjs-types": "^0.8.0",
         "long": "^4.0.0",
         "protobufjs": "~6.11.3",
         "xstream": "^11.14.0"
+      },
+      "dependencies": {
+        "cosmjs-types": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.8.0.tgz",
+          "integrity": "sha512-Q2Mj95Fl0PYMWEhA2LuGEIhipF7mQwd9gTQ85DdP9jjjopeoGaDxvmPa5nakNzsq7FnO1DMTatXTAx6bxMH7Lg==",
+          "requires": {
+            "long": "^4.0.0",
+            "protobufjs": "~6.11.2"
+          }
+        }
       }
     },
     "@cosmjs/stream": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.29.5.tgz",
-      "integrity": "sha512-TToTDWyH1p05GBtF0Y8jFw2C+4783ueDCmDyxOMM6EU82IqpmIbfwcdMOCAm0JhnyMh+ocdebbFvnX/sGKzRAA==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.31.3.tgz",
+      "integrity": "sha512-8keYyI7X0RjsLyVcZuBeNjSv5FA4IHwbFKx7H60NHFXszN8/MvXL6aZbNIvxtcIHHsW7K9QSQos26eoEWlAd+w==",
       "requires": {
         "xstream": "^11.14.0"
       }
     },
     "@cosmjs/tendermint-rpc": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.29.5.tgz",
-      "integrity": "sha512-ar80twieuAxsy0x2za/aO3kBr2DFPAXDmk2ikDbmkda+qqfXgl35l9CVAAjKRqd9d+cRvbQyb5M4wy6XQpEV6w==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.31.3.tgz",
+      "integrity": "sha512-s3TiWkPCW4QceTQjpYqn4xttUJH36mTPqplMl+qyocdqk5+X5mergzExU/pHZRWQ4pbby8bnR7kMvG4OC1aZ8g==",
       "requires": {
-        "@cosmjs/crypto": "^0.29.5",
-        "@cosmjs/encoding": "^0.29.5",
-        "@cosmjs/json-rpc": "^0.29.5",
-        "@cosmjs/math": "^0.29.5",
-        "@cosmjs/socket": "^0.29.5",
-        "@cosmjs/stream": "^0.29.5",
-        "@cosmjs/utils": "^0.29.5",
+        "@cosmjs/crypto": "^0.31.3",
+        "@cosmjs/encoding": "^0.31.3",
+        "@cosmjs/json-rpc": "^0.31.3",
+        "@cosmjs/math": "^0.31.3",
+        "@cosmjs/socket": "^0.31.3",
+        "@cosmjs/stream": "^0.31.3",
+        "@cosmjs/utils": "^0.31.3",
         "axios": "^0.21.2",
         "readonly-date": "^1.0.0",
         "xstream": "^11.14.0"
       }
     },
     "@cosmjs/utils": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.5.tgz",
-      "integrity": "sha512-m7h+RXDUxOzEOGt4P+3OVPX7PuakZT3GBmaM/Y2u+abN3xZkziykD/NvedYFvvCCdQo714XcGl33bwifS9FZPQ=="
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.31.3.tgz",
+      "integrity": "sha512-VBhAgzrrYdIe0O5IbKRqwszbQa7ZyQLx9nEQuHQ3HUplQW7P44COG/ye2n6AzCudtqxmwdX7nyX8ta1J07GoqA=="
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -5821,23 +5596,10 @@
         "type-check": "~0.4.0"
       }
     },
-    "libsodium": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.13.tgz",
-      "integrity": "sha512-mK8ju0fnrKXXfleL53vtp9xiPq5hKM0zbDQtcxQIsSmxNgSxqCj6R7Hl9PkrNe2j29T4yoDaF7DJLK9/i5iWUw=="
-    },
     "libsodium-sumo": {
       "version": "0.7.13",
       "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.13.tgz",
       "integrity": "sha512-zTGdLu4b9zSNLfovImpBCbdAA4xkpkZbMnSQjP8HShyOutnGjRHmSOKlsylh1okao6QhLiz7nG98EGn+04cZjQ=="
-    },
-    "libsodium-wrappers": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.13.tgz",
-      "integrity": "sha512-kasvDsEi/r1fMzKouIDv7B8I6vNmknXwGiYodErGuESoFTohGSKZplFtVxZqHaoQ217AynyIFgnOVRitpHs0Qw==",
-      "requires": {
-        "libsodium": "^0.7.13"
-      }
     },
     "libsodium-wrappers-sumo": {
       "version": "0.7.13",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@commander-js/extra-typings": "^11.1.0",
     "@cosmjs/cosmwasm-stargate": "^0.31.3",
-    "@cosmjs/stargate": "^0.29.3",
+    "@cosmjs/stargate": "^0.31.3",
     "chalk": "^4.0.0",
     "cosmjs-types": "^0.5.2",
     "fireblocks-sdk": "^4.0.0",

--- a/src/tx.ts
+++ b/src/tx.ts
@@ -52,7 +52,7 @@ function createDefaultTypes (): AminoConverters {
     ...createBankAminoConverters(),
     ...createDistributionAminoConverters(),
     ...createGovAminoConverters(),
-    ...createStakingAminoConverters('cosmos'),
+    ...createStakingAminoConverters(),
     ...createIbcAminoConverters(),
     ...createVestingAminoConverters()
   }
@@ -72,7 +72,7 @@ function toCoin (amount: string, expectedDenom: string): Coin {
     )
   }
 
-  return coin(Number(total), denom)
+  return coin(total, denom)
 }
 
 export async function genSignableTx (
@@ -103,10 +103,10 @@ export async function genSignableTx (
     })
   }
 
-  const feeAmt: number =
+  const feeAmt: bigint =
         config.network.fee ?? config.network.gasPrice * config.network.gas
   const fee: StdFee = {
-    amount: [coin(feeAmt, config.network.denom)],
+    amount: [coin(feeAmt.toString(), config.network.denom)],
     gas: config.network.gas.toString()
   }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -53,15 +53,15 @@ export interface NetworkConfig {
   denom: string
 
   // default TX gas e.g 200000
-  gas: number
+  gas: bigint
 
   // gas price e.g 0.4
   // https://github.com/cosmos/chain-registry/blob/master/celestia/chain.json
-  gasPrice: number
+  gasPrice: bigint
 
   // fixed fee paid for TX - this will override the gasPrice * gas = fee
   // calculation
-  fee?: number
+  fee?: bigint
 
   // block explorer URL to display Transaction ID via Web UI. Example:
   //   https://mintscan.io/celestia/tx/


### PR DESCRIPTION
# TL;DR
Some cosmos-sdk based networks like dYdX used eth compatible denom such as `adydx` that stands for `10^18`. To handle the denominator correctly the code needs to process the big integers instead of just ints.

# Test Plan
Tested with dydx mainnet and celestia testnet (no changes for the latter).
```
# celestia
npm run fireblocks-staking -- tx delegate 10utia -b  --config ./config.testnet.json --signer local
https://testnet.celestia.explorers.guru/transaction/90969E2ADA917A7FE0218B3664F10630E0B5329FF97A16DA93B27CD70A61ED19

# dydx (the TX gets broadcasted but fails due to insufficient funds and that is what we expect)
npm run fireblocks-staking -- tx delegate 100000000000000000000000adydx -b  --config ./config.mainnet.json --signer local
https://mintscan.io/dydx/txs/25BE616A40B62547B8D48C1C71CDD491DFEC4B39176733039917BF29D190A683
```