### PR TITLE
add memo to transaction

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,7 @@ function makeTxCommand (): Command {
   const tx = new Command('tx')
     .description('generate a signed transaction')
     .option('-b, --broadcast', 'broadcast generated transaction', false)
+    .option('-m, --memo <memo>', 'a note attached to transaction', '')
     .option('-j, --journal <value>', 'write TX\'es to the local journal log', 'true')
 
   tx.command('delegate')
@@ -151,6 +152,7 @@ async function runDelegateOrUndelegateTx (
   cmd: Command<[string]>
 ): Promise<[StdSignDoc, Uint8Array]> {
   const broadcastEnabled = cmd.parent?.getOptionValue('broadcast') as boolean
+  const memo = cmd.parent?.getOptionValue('memo') as string
   const journalEnabled: boolean = JSON.parse(cmd.parent?.getOptionValue('journal') as string)
 
   const [config, chainID, cosmosAccount, vault, cosmosClient, signerClient] =
@@ -162,7 +164,8 @@ async function runDelegateOrUndelegateTx (
     chainID,
     amount,
     cosmosAccount.accountNumber,
-    cosmosAccount.sequence
+    cosmosAccount.sequence,
+    memo
   )
 
   print(1, 3, 'prepare unsigned transaction')

--- a/src/tx.ts
+++ b/src/tx.ts
@@ -81,7 +81,8 @@ export async function genSignableTx (
   chainID: string,
   amount: string,
   accountNumber: number,
-  accountSequence: number
+  accountSequence: number,
+  memo: string
 ): Promise<StdSignDoc> {
   const aminoTypes = new AminoTypes(createDefaultTypes())
 
@@ -114,7 +115,7 @@ export async function genSignableTx (
     [delegateMsg].map((msg) => aminoTypes.toAmino(msg)),
     fee,
     chainID,
-    '', // memo
+    memo,
     accountNumber,
     accountSequence
   )


### PR DESCRIPTION
## What

This allows a user to specify transaction `memo`.

## Test plan
```
# without memo
$ npm run fireblocks-staking -- tx delegate 10utia -b  --config ./config.testnet.json
https://testnet.celestia.explorers.guru/transaction/0D7BF8F643EAA8EF5AF6C0A8D5B62922E38BCD16697FB74BC0A105242BCD8A13

# with memo
$ npm run fireblocks-staking -- tx delegate 10utia -b  --config ./config.testnet.json  --memo 'test1234'
https://testnet.celestia.explorers.guru/transaction/81C5B8BF6C9EB7617FE273E34DA7A0A9010B98E353882B22456FDB320149ECF8
```