### PR TITLE
attach unsigned transaction as a note

### DIFF
--- a/src/tx.ts
+++ b/src/tx.ts
@@ -140,6 +140,8 @@ export async function genSignedMsg (
       id: vault.id,
       address: delegatorAddress
     },
+    // display raw TX in Fireblocks UI
+    note: JSON.stringify(signDoc, null, 2),
     operation: TransactionOperation.RAW,
     extraParameters: {
       rawMessageData: {


### PR DESCRIPTION
# What
This changes attaches a raw unsigned TX JSON as a note to Fireblocks API request. With that you can see in the UI, not only the signature request data but also a human verifiable transaction.

# Test plan
Executed TX: https://testnet.celestia.explorers.guru/transaction/EEED1798FFF968006F6E0DE11B88A8A133D3274BA5BF41B9CCCFE4E3EDABCF22 and eyeballed the UI where I can see the JSON TX