### PR TITLE
Polkadot / subtrate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,21 @@ Here's an example configuration for NEAR mainnet:
 }
 ```
 
+### Substrate (Polkadot, Kusama, ...)
+Here's and example configuration for Polkadot testnet (Westend):
+```
+"substrate": {
+    "rpcUrl": "wss://westend.public.curie.radiumblock.co/ws",
+    "denomMultiplier": 1000000000000,
+    "rewardDestination": "Stash",
+    "blockExplorerUrl": "https://westend.subscan.io/account"
+}
+```
+
+Please note that staking in Substrate networks requires multiple transactions. This is:
+1. `bond` - to bond the initial amount of tokens (use `bond-extra` if you wish to stake more tokens but you already run `bond`)
+2. `nominate` - nominates the stake to a validator address present in the config
+
 ## Usage
 Please note that unless you pass the `--broadcast` flag, your transaction will not be sent to the network. Signing a transaction and broadcasting it are two separate actions. Therefore, having a signed transaction does not affect your account unless it is broadcasted and processed by the network.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@cosmjs/cosmwasm-stargate": "^0.31.3",
         "@cosmjs/stargate": "^0.31.3",
         "@near-js/types": "^0.2.0",
+        "@polkadot/api": "^11.1.1",
         "chalk": "^4.0.0",
         "cosmjs-types": "^0.5.2",
         "fireblocks-sdk": "^4.0.0",
@@ -549,6 +550,645 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@polkadot-api/json-rpc-provider": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider/-/json-rpc-provider-0.0.1.tgz",
+      "integrity": "sha512-/SMC/l7foRjpykLTUTacIH05H3mr9ip8b5xxfwXlVezXrNVLp3Cv0GX6uItkKd+ZjzVPf3PFrDF2B2/HLSNESA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot-api/json-rpc-provider-proxy": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider-proxy/-/json-rpc-provider-proxy-0.0.1.tgz",
+      "integrity": "sha512-gmVDUP8LpCH0BXewbzqXF2sdHddq1H1q+XrAW2of+KZj4woQkIGBRGTJHeBEVHe30EB+UejR1N2dT4PO/RvDdg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot-api/metadata-builders": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.0.1.tgz",
+      "integrity": "sha512-GCI78BHDzXAF/L2pZD6Aod/yl82adqQ7ftNmKg51ixRL02JpWUA+SpUKTJE5MY1p8kiJJIo09P2um24SiJHxNA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/substrate-bindings": "0.0.1",
+        "@polkadot-api/utils": "0.0.1"
+      }
+    },
+    "node_modules/@polkadot-api/observable-client": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.1.0.tgz",
+      "integrity": "sha512-GBCGDRztKorTLna/unjl/9SWZcRmvV58o9jwU2Y038VuPXZcr01jcw/1O3x+yeAuwyGzbucI/mLTDa1QoEml3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/metadata-builders": "0.0.1",
+        "@polkadot-api/substrate-bindings": "0.0.1",
+        "@polkadot-api/substrate-client": "0.0.1",
+        "@polkadot-api/utils": "0.0.1"
+      },
+      "peerDependencies": {
+        "rxjs": ">=7.8.0"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-bindings": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.0.1.tgz",
+      "integrity": "sha512-bAe7a5bOPnuFVmpv7y4BBMRpNTnMmE0jtTqRUw/+D8ZlEHNVEJQGr4wu3QQCl7k1GnSV1wfv3mzIbYjErEBocg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@noble/hashes": "^1.3.1",
+        "@polkadot-api/utils": "0.0.1",
+        "@scure/base": "^1.1.1",
+        "scale-ts": "^1.6.0"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-client": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.0.1.tgz",
+      "integrity": "sha512-9Bg9SGc3AwE+wXONQoW8GC00N3v6lCZLW74HQzqB6ROdcm5VAHM4CB/xRzWSUF9CXL78ugiwtHx3wBcpx4H4Wg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot-api/utils": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.0.1.tgz",
+      "integrity": "sha512-3j+pRmlF9SgiYDabSdZsBSsN5XHbpXOAce1lWj56IEEaFZVjsiCaxDOA7C9nCcgfVXuvnbxqqEGQvnY+QfBAUw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@polkadot/api": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-11.1.1.tgz",
+      "integrity": "sha512-SGKIFMan0o4cjRxpndAaEG7aPb9TwAPVgjS/DKJDpzdKA7rEqDTe+SFw/vuzbt9CSl2nx1LBd10xbOeV7Ak+KA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api-augment": "11.1.1",
+        "@polkadot/api-base": "11.1.1",
+        "@polkadot/api-derive": "11.1.1",
+        "@polkadot/keyring": "^12.6.2",
+        "@polkadot/rpc-augment": "11.1.1",
+        "@polkadot/rpc-core": "11.1.1",
+        "@polkadot/rpc-provider": "11.1.1",
+        "@polkadot/types": "11.1.1",
+        "@polkadot/types-augment": "11.1.1",
+        "@polkadot/types-codec": "11.1.1",
+        "@polkadot/types-create": "11.1.1",
+        "@polkadot/types-known": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/util-crypto": "^12.6.2",
+        "eventemitter3": "^5.0.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-augment": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-11.1.1.tgz",
+      "integrity": "sha512-3rJZmW5RH/A9ajO75Fmc20FMQRFytk/hZOqFAlhik/UuRCOgtU4fNouSWaWN0a75iBT8+01/sS917XRibHDysQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api-base": "11.1.1",
+        "@polkadot/rpc-augment": "11.1.1",
+        "@polkadot/types": "11.1.1",
+        "@polkadot/types-augment": "11.1.1",
+        "@polkadot/types-codec": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-base": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-11.1.1.tgz",
+      "integrity": "sha512-+hH7Azj7pOj0iyjLj8ORxJVNUKAfZCH68rM9VQRs+/N9NmpxSMx8AxBKCynSgSJoiDXr84Zm862wJHoa4Ytf2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-core": "11.1.1",
+        "@polkadot/types": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/api-derive": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-11.1.1.tgz",
+      "integrity": "sha512-OR2DfUg9Nd3JvCw3hUXbLPyiaUBPzb1mVXc2qngqdz4Y1Sg0yakTwKjSiFBEgQE7qO0Fjq9BYKLi5Ci66jciAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api": "11.1.1",
+        "@polkadot/api-augment": "11.1.1",
+        "@polkadot/api-base": "11.1.1",
+        "@polkadot/rpc-core": "11.1.1",
+        "@polkadot/types": "11.1.1",
+        "@polkadot/types-codec": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/util-crypto": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/keyring": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.6.2.tgz",
+      "integrity": "sha512-O3Q7GVmRYm8q7HuB3S0+Yf/q/EB2egKRRU3fv9b3B7V+A52tKzA+vIwEmNVaD1g5FKW9oB97rmpggs0zaKFqHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "12.6.2",
+        "@polkadot/util-crypto": "12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "12.6.2",
+        "@polkadot/util-crypto": "12.6.2"
+      }
+    },
+    "node_modules/@polkadot/networks": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.6.2.tgz",
+      "integrity": "sha512-1oWtZm1IvPWqvMrldVH6NI2gBoCndl5GEwx7lAuQWGr7eNL+6Bdc5K3Z9T0MzFvDGoi2/CBqjX9dRKo39pDC/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "12.6.2",
+        "@substrate/ss58-registry": "^1.44.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-augment": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-11.1.1.tgz",
+      "integrity": "sha512-jkKhKAqgPivgNltmLmeD7oiMD6ekxe9bv2qOGEc1BVopSnS+PXCuGOeftTuv7Qo4rXaoEkMP1rlxmbjOZ4o3sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-core": "11.1.1",
+        "@polkadot/types": "11.1.1",
+        "@polkadot/types-codec": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-core": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-11.1.1.tgz",
+      "integrity": "sha512-XDEIxWajwS0DIJeqImWYeSDHcMZNXUDunI+mXK/ihtZJY6/s3CY1UHo6SgdWCK05IukQhr9CjRVtKNU7DYGS4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-augment": "11.1.1",
+        "@polkadot/rpc-provider": "11.1.1",
+        "@polkadot/types": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/rpc-provider": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-11.1.1.tgz",
+      "integrity": "sha512-m4v964Cs7dM9cLiMD5XVLPvKAT1yOcvTX618875pLe5LU67b7MLUT2xxCchXf61jvM6b3NKNKulKSMmlQJkYtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/keyring": "^12.6.2",
+        "@polkadot/types": "11.1.1",
+        "@polkadot/types-support": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/util-crypto": "^12.6.2",
+        "@polkadot/x-fetch": "^12.6.2",
+        "@polkadot/x-global": "^12.6.2",
+        "@polkadot/x-ws": "^12.6.2",
+        "eventemitter3": "^5.0.1",
+        "mock-socket": "^9.3.1",
+        "nock": "^13.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@substrate/connect": "0.8.10"
+      }
+    },
+    "node_modules/@polkadot/types": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-11.1.1.tgz",
+      "integrity": "sha512-v4cbkRXYGcgtESg5oF/fVFNSrkmxw+rFxWslOWVB0mDJ74ooPDyasBR0FjxrPdoMlbxtrBbs+TixFEKng63chA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/keyring": "^12.6.2",
+        "@polkadot/types-augment": "11.1.1",
+        "@polkadot/types-codec": "11.1.1",
+        "@polkadot/types-create": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/util-crypto": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-augment": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-11.1.1.tgz",
+      "integrity": "sha512-aBfM+vu76YIym8Dvy00FJZRVz9cHqeghlTj3Lj1WjolVc+GuFxAWDx87p778Sb9d+iebA3pVY0wXNF+ZlRNDtg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/types": "11.1.1",
+        "@polkadot/types-codec": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-codec": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-11.1.1.tgz",
+      "integrity": "sha512-YMLEwerOO17M++EUAnh0SQWcDQNZ/l2nGmbSSvLEUBZdjXdtfLQ8NFVZakH5ehNHD+X3t0NLOQJg0hOBlVIj4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/x-bigint": "^12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-create": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-11.1.1.tgz",
+      "integrity": "sha512-Ro/9lYyEhGYTFoIvFUvAzdJ+0Of/tVnqewtwV35iXX9C86GazE8URJPrHFh4J/GBLQY0/JiT++PwxwFNH/kJsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/types-codec": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-known": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-11.1.1.tgz",
+      "integrity": "sha512-Kp+KrCIxy8FkfqzyV/KpRGJC8bBAK8eKC/ta7bCo++kmdGc9FFfpmTMPIYOtd8vxYdL71KA40bI9LqodCaopQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/networks": "^12.6.2",
+        "@polkadot/types": "11.1.1",
+        "@polkadot/types-codec": "11.1.1",
+        "@polkadot/types-create": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/types-support": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-11.1.1.tgz",
+      "integrity": "sha512-Wf1aYs5lEtwksFH8EBNZMxBJlcRFx/sewErzpwGJJFT8BGcrQpc6HlNjVXJpTdXj+0VzUBHE9B8eAWfWQl8YIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "^12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.6.2.tgz",
+      "integrity": "sha512-l8TubR7CLEY47240uki0TQzFvtnxFIO7uI/0GoWzpYD/O62EIAMRsuY01N4DuwgKq2ZWD59WhzsLYmA5K6ksdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "12.6.2",
+        "@polkadot/x-global": "12.6.2",
+        "@polkadot/x-textdecoder": "12.6.2",
+        "@polkadot/x-textencoder": "12.6.2",
+        "@types/bn.js": "^5.1.5",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/util-crypto": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.6.2.tgz",
+      "integrity": "sha512-FEWI/dJ7wDMNN1WOzZAjQoIcCP/3vz3wvAp5QQm+lOrzOLj0iDmaIGIcBkz8HVm3ErfSe/uKP0KS4jgV/ib+Mg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "12.6.2",
+        "@polkadot/util": "12.6.2",
+        "@polkadot/wasm-crypto": "^7.3.2",
+        "@polkadot/wasm-util": "^7.3.2",
+        "@polkadot/x-bigint": "12.6.2",
+        "@polkadot/x-randomvalues": "12.6.2",
+        "@scure/base": "^1.1.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "12.6.2"
+      }
+    },
+    "node_modules/@polkadot/util-crypto/node_modules/@noble/curves": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
+      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polkadot/util-crypto/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polkadot/wasm-bridge": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.3.2.tgz",
+      "integrity": "sha512-AJEXChcf/nKXd5Q/YLEV5dXQMle3UNT7jcXYmIffZAo/KI394a+/24PaISyQjoNC0fkzS1Q8T5pnGGHmXiVz2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.3.2.tgz",
+      "integrity": "sha512-+neIDLSJ6jjVXsjyZ5oLSv16oIpwp+PxFqTUaZdZDoA2EyFRQB8pP7+qLsMNk+WJuhuJ4qXil/7XiOnZYZ+wxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.3.2",
+        "@polkadot/wasm-crypto-asmjs": "7.3.2",
+        "@polkadot/wasm-crypto-init": "7.3.2",
+        "@polkadot/wasm-crypto-wasm": "7.3.2",
+        "@polkadot/wasm-util": "7.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-asmjs": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.3.2.tgz",
+      "integrity": "sha512-QP5eiUqUFur/2UoF2KKKYJcesc71fXhQFLT3D4ZjG28Mfk2ZPI0QNRUfpcxVQmIUpV5USHg4geCBNuCYsMm20Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-init": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.3.2.tgz",
+      "integrity": "sha512-FPq73zGmvZtnuJaFV44brze3Lkrki3b4PebxCy9Fplw8nTmisKo9Xxtfew08r0njyYh+uiJRAxPCXadkC9sc8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.3.2",
+        "@polkadot/wasm-crypto-asmjs": "7.3.2",
+        "@polkadot/wasm-crypto-wasm": "7.3.2",
+        "@polkadot/wasm-util": "7.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-wasm": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.3.2.tgz",
+      "integrity": "sha512-15wd0EMv9IXs5Abp1ZKpKKAVyZPhATIAHfKsyoWCEFDLSOA0/K0QGOxzrAlsrdUkiKZOq7uzSIgIDgW8okx2Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-util": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.3.2.tgz",
+      "integrity": "sha512-bmD+Dxo1lTZyZNxbyPE380wd82QsX+43mgCm40boyKrRppXEyQmWT98v/Poc7chLuskYb6X8IQ6lvvK2bGR4Tg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-bigint": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.6.2.tgz",
+      "integrity": "sha512-HSIk60uFPX4GOFZSnIF7VYJz7WZA7tpFJsne7SzxOooRwMTWEtw3fUpFy5cYYOeLh17/kHH1Y7SVcuxzVLc74Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-fetch": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.6.2.tgz",
+      "integrity": "sha512-8wM/Z9JJPWN1pzSpU7XxTI1ldj/AfC8hKioBlUahZ8gUiJaOF7K9XEFCrCDLis/A1BoOu7Ne6WMx/vsJJIbDWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "12.6.2",
+        "node-fetch": "^3.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-fetch/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@polkadot/x-global": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.6.2.tgz",
+      "integrity": "sha512-a8d6m+PW98jmsYDtAWp88qS4dl8DyqUBsd0S+WgyfSMtpEXu6v9nXDgPZgwF5xdDvXhm+P0ZfVkVTnIGrScb5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-randomvalues": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.6.2.tgz",
+      "integrity": "sha512-Vr8uG7rH2IcNJwtyf5ebdODMcr0XjoCpUbI91Zv6AlKVYOGKZlKLYJHIwpTaKKB+7KPWyQrk4Mlym/rS7v9feg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "12.6.2",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-textdecoder": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.6.2.tgz",
+      "integrity": "sha512-M1Bir7tYvNappfpFWXOJcnxUhBUFWkUFIdJSyH0zs5LmFtFdbKAeiDXxSp2Swp5ddOZdZgPac294/o2TnQKN1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-textencoder": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.6.2.tgz",
+      "integrity": "sha512-4N+3UVCpI489tUJ6cv3uf0PjOHvgGp9Dl+SZRLgFGt9mvxnvpW/7+XBADRMtlG4xi5gaRK7bgl5bmY6OMDsNdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-ws": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.6.2.tgz",
+      "integrity": "sha512-cGZWo7K5eRRQCRl2LrcyCYsrc3lRbTlixZh3AzgU8uX4wASVGRlNWi/Hf4TtHNe1ExCDmxabJzdIsABIfrr7xw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2",
+        "ws": "^8.15.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-ws/node_modules/ws": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -602,6 +1242,76 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.6.tgz",
+      "integrity": "sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@substrate/connect": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.10.tgz",
+      "integrity": "sha512-DIyQ13DDlXqVFnLV+S6/JDgiGowVRRrh18kahieJxhgvzcWicw5eLc6jpfQ0moVVLBYkO7rctB5Wreldwpva8w==",
+      "license": "GPL-3.0-only",
+      "optional": true,
+      "dependencies": {
+        "@substrate/connect-extension-protocol": "^2.0.0",
+        "@substrate/connect-known-chains": "^1.1.4",
+        "@substrate/light-client-extension-helpers": "^0.0.6",
+        "smoldot": "2.0.22"
+      }
+    },
+    "node_modules/@substrate/connect-extension-protocol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-2.0.0.tgz",
+      "integrity": "sha512-nKu8pDrE3LNCEgJjZe1iGXzaD6OSIDD4Xzz/yo4KO9mQ6LBvf49BVrt4qxBFGL6++NneLiWUZGoh+VSd4PyVIg==",
+      "license": "GPL-3.0-only",
+      "optional": true
+    },
+    "node_modules/@substrate/connect-known-chains": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-known-chains/-/connect-known-chains-1.1.4.tgz",
+      "integrity": "sha512-iT+BdKqvKl/uBLd8BAJysFM1BaMZXRkaXBP2B7V7ob/EyNs5h0EMhTVbO6MJxV/IEOg5OKsyl6FUqQK7pKnqyw==",
+      "license": "GPL-3.0-only",
+      "optional": true
+    },
+    "node_modules/@substrate/light-client-extension-helpers": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@substrate/light-client-extension-helpers/-/light-client-extension-helpers-0.0.6.tgz",
+      "integrity": "sha512-girltEuxQ1BvkJWmc8JJlk4ZxnlGXc/wkLcNguhY+UoDEMBK0LsdtfzQKIfrIehi4QdeSBlFEFBoI4RqPmsZzA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "0.0.1",
+        "@polkadot-api/json-rpc-provider-proxy": "0.0.1",
+        "@polkadot-api/observable-client": "0.1.0",
+        "@polkadot-api/substrate-client": "0.0.1",
+        "@substrate/connect-extension-protocol": "^2.0.0",
+        "@substrate/connect-known-chains": "^1.1.4",
+        "rxjs": "^7.8.1"
+      },
+      "peerDependencies": {
+        "smoldot": "2.x"
+      }
+    },
+    "node_modules/@substrate/ss58-registry": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.48.0.tgz",
+      "integrity": "sha512-lE9TGgtd93fTEIoHhSdtvSFBoCsvTbqiCvQIMvX4m6BO/hESywzzTzTFMVP1doBwDDMAN4lsMfIM3X3pdmt7kQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@types/bn.js": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.5.tgz",
+      "integrity": "sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1266,11 +1976,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1286,8 +2004,7 @@
     "node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/decimal.js": {
       "version": "10.4.2",
@@ -1869,6 +2586,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1922,6 +2645,29 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -2053,6 +2799,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fraction.js": {
@@ -2788,6 +3546,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
@@ -3020,6 +3784,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mock-socket": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+      "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/moment": {
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
@@ -3083,6 +3856,39 @@
         "http-errors": "1.7.2",
         "near-abi": "0.1.1",
         "node-fetch": "2.6.7"
+      }
+    },
+    "node_modules/nock": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
+      "integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
@@ -3326,6 +4132,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "6.11.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
@@ -3530,6 +4345,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
@@ -3580,6 +4404,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/scale-ts": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/scale-ts/-/scale-ts-1.6.0.tgz",
+      "integrity": "sha512-Ja5VCjNZR8TGKhUumy9clVVxcDpM+YFjAnkMuwQy68Hixio3VRRvWdE3g8T/yC+HXA0ZDQl2TGyUmtmbcVl40Q==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/seedrandom": {
       "version": "3.0.5",
@@ -3675,6 +4506,38 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/smoldot": {
+      "version": "2.0.22",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.22.tgz",
+      "integrity": "sha512-B50vRgTY6v3baYH6uCgL15tfaag5tcS2o/P5q1OiXcKGv1axZDfz2dzzMuIkVpyMR2ug11F6EAtQlmYBQd292g==",
+      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
+      "optional": true,
+      "dependencies": {
+        "ws": "^8.8.1"
+      }
+    },
+    "node_modules/smoldot/node_modules/ws": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/split-on-first": {
@@ -3873,6 +4736,12 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4018,6 +4887,15 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -4594,6 +5472,453 @@
         "fastq": "^1.6.0"
       }
     },
+    "@polkadot-api/json-rpc-provider": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider/-/json-rpc-provider-0.0.1.tgz",
+      "integrity": "sha512-/SMC/l7foRjpykLTUTacIH05H3mr9ip8b5xxfwXlVezXrNVLp3Cv0GX6uItkKd+ZjzVPf3PFrDF2B2/HLSNESA==",
+      "optional": true
+    },
+    "@polkadot-api/json-rpc-provider-proxy": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider-proxy/-/json-rpc-provider-proxy-0.0.1.tgz",
+      "integrity": "sha512-gmVDUP8LpCH0BXewbzqXF2sdHddq1H1q+XrAW2of+KZj4woQkIGBRGTJHeBEVHe30EB+UejR1N2dT4PO/RvDdg==",
+      "optional": true
+    },
+    "@polkadot-api/metadata-builders": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.0.1.tgz",
+      "integrity": "sha512-GCI78BHDzXAF/L2pZD6Aod/yl82adqQ7ftNmKg51ixRL02JpWUA+SpUKTJE5MY1p8kiJJIo09P2um24SiJHxNA==",
+      "optional": true,
+      "requires": {
+        "@polkadot-api/substrate-bindings": "0.0.1",
+        "@polkadot-api/utils": "0.0.1"
+      }
+    },
+    "@polkadot-api/observable-client": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.1.0.tgz",
+      "integrity": "sha512-GBCGDRztKorTLna/unjl/9SWZcRmvV58o9jwU2Y038VuPXZcr01jcw/1O3x+yeAuwyGzbucI/mLTDa1QoEml3A==",
+      "optional": true,
+      "requires": {
+        "@polkadot-api/metadata-builders": "0.0.1",
+        "@polkadot-api/substrate-bindings": "0.0.1",
+        "@polkadot-api/substrate-client": "0.0.1",
+        "@polkadot-api/utils": "0.0.1"
+      }
+    },
+    "@polkadot-api/substrate-bindings": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.0.1.tgz",
+      "integrity": "sha512-bAe7a5bOPnuFVmpv7y4BBMRpNTnMmE0jtTqRUw/+D8ZlEHNVEJQGr4wu3QQCl7k1GnSV1wfv3mzIbYjErEBocg==",
+      "optional": true,
+      "requires": {
+        "@noble/hashes": "^1.3.1",
+        "@polkadot-api/utils": "0.0.1",
+        "@scure/base": "^1.1.1",
+        "scale-ts": "^1.6.0"
+      }
+    },
+    "@polkadot-api/substrate-client": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.0.1.tgz",
+      "integrity": "sha512-9Bg9SGc3AwE+wXONQoW8GC00N3v6lCZLW74HQzqB6ROdcm5VAHM4CB/xRzWSUF9CXL78ugiwtHx3wBcpx4H4Wg==",
+      "optional": true
+    },
+    "@polkadot-api/utils": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.0.1.tgz",
+      "integrity": "sha512-3j+pRmlF9SgiYDabSdZsBSsN5XHbpXOAce1lWj56IEEaFZVjsiCaxDOA7C9nCcgfVXuvnbxqqEGQvnY+QfBAUw==",
+      "optional": true
+    },
+    "@polkadot/api": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-11.1.1.tgz",
+      "integrity": "sha512-SGKIFMan0o4cjRxpndAaEG7aPb9TwAPVgjS/DKJDpzdKA7rEqDTe+SFw/vuzbt9CSl2nx1LBd10xbOeV7Ak+KA==",
+      "requires": {
+        "@polkadot/api-augment": "11.1.1",
+        "@polkadot/api-base": "11.1.1",
+        "@polkadot/api-derive": "11.1.1",
+        "@polkadot/keyring": "^12.6.2",
+        "@polkadot/rpc-augment": "11.1.1",
+        "@polkadot/rpc-core": "11.1.1",
+        "@polkadot/rpc-provider": "11.1.1",
+        "@polkadot/types": "11.1.1",
+        "@polkadot/types-augment": "11.1.1",
+        "@polkadot/types-codec": "11.1.1",
+        "@polkadot/types-create": "11.1.1",
+        "@polkadot/types-known": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/util-crypto": "^12.6.2",
+        "eventemitter3": "^5.0.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/api-augment": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-11.1.1.tgz",
+      "integrity": "sha512-3rJZmW5RH/A9ajO75Fmc20FMQRFytk/hZOqFAlhik/UuRCOgtU4fNouSWaWN0a75iBT8+01/sS917XRibHDysQ==",
+      "requires": {
+        "@polkadot/api-base": "11.1.1",
+        "@polkadot/rpc-augment": "11.1.1",
+        "@polkadot/types": "11.1.1",
+        "@polkadot/types-augment": "11.1.1",
+        "@polkadot/types-codec": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/api-base": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-11.1.1.tgz",
+      "integrity": "sha512-+hH7Azj7pOj0iyjLj8ORxJVNUKAfZCH68rM9VQRs+/N9NmpxSMx8AxBKCynSgSJoiDXr84Zm862wJHoa4Ytf2g==",
+      "requires": {
+        "@polkadot/rpc-core": "11.1.1",
+        "@polkadot/types": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/api-derive": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-11.1.1.tgz",
+      "integrity": "sha512-OR2DfUg9Nd3JvCw3hUXbLPyiaUBPzb1mVXc2qngqdz4Y1Sg0yakTwKjSiFBEgQE7qO0Fjq9BYKLi5Ci66jciAw==",
+      "requires": {
+        "@polkadot/api": "11.1.1",
+        "@polkadot/api-augment": "11.1.1",
+        "@polkadot/api-base": "11.1.1",
+        "@polkadot/rpc-core": "11.1.1",
+        "@polkadot/types": "11.1.1",
+        "@polkadot/types-codec": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/util-crypto": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/keyring": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-12.6.2.tgz",
+      "integrity": "sha512-O3Q7GVmRYm8q7HuB3S0+Yf/q/EB2egKRRU3fv9b3B7V+A52tKzA+vIwEmNVaD1g5FKW9oB97rmpggs0zaKFqHw==",
+      "requires": {
+        "@polkadot/util": "12.6.2",
+        "@polkadot/util-crypto": "12.6.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/networks": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-12.6.2.tgz",
+      "integrity": "sha512-1oWtZm1IvPWqvMrldVH6NI2gBoCndl5GEwx7lAuQWGr7eNL+6Bdc5K3Z9T0MzFvDGoi2/CBqjX9dRKo39pDC/w==",
+      "requires": {
+        "@polkadot/util": "12.6.2",
+        "@substrate/ss58-registry": "^1.44.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/rpc-augment": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-11.1.1.tgz",
+      "integrity": "sha512-jkKhKAqgPivgNltmLmeD7oiMD6ekxe9bv2qOGEc1BVopSnS+PXCuGOeftTuv7Qo4rXaoEkMP1rlxmbjOZ4o3sg==",
+      "requires": {
+        "@polkadot/rpc-core": "11.1.1",
+        "@polkadot/types": "11.1.1",
+        "@polkadot/types-codec": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/rpc-core": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-11.1.1.tgz",
+      "integrity": "sha512-XDEIxWajwS0DIJeqImWYeSDHcMZNXUDunI+mXK/ihtZJY6/s3CY1UHo6SgdWCK05IukQhr9CjRVtKNU7DYGS4Q==",
+      "requires": {
+        "@polkadot/rpc-augment": "11.1.1",
+        "@polkadot/rpc-provider": "11.1.1",
+        "@polkadot/types": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/rpc-provider": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-11.1.1.tgz",
+      "integrity": "sha512-m4v964Cs7dM9cLiMD5XVLPvKAT1yOcvTX618875pLe5LU67b7MLUT2xxCchXf61jvM6b3NKNKulKSMmlQJkYtw==",
+      "requires": {
+        "@polkadot/keyring": "^12.6.2",
+        "@polkadot/types": "11.1.1",
+        "@polkadot/types-support": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/util-crypto": "^12.6.2",
+        "@polkadot/x-fetch": "^12.6.2",
+        "@polkadot/x-global": "^12.6.2",
+        "@polkadot/x-ws": "^12.6.2",
+        "@substrate/connect": "0.8.10",
+        "eventemitter3": "^5.0.1",
+        "mock-socket": "^9.3.1",
+        "nock": "^13.5.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/types": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-11.1.1.tgz",
+      "integrity": "sha512-v4cbkRXYGcgtESg5oF/fVFNSrkmxw+rFxWslOWVB0mDJ74ooPDyasBR0FjxrPdoMlbxtrBbs+TixFEKng63chA==",
+      "requires": {
+        "@polkadot/keyring": "^12.6.2",
+        "@polkadot/types-augment": "11.1.1",
+        "@polkadot/types-codec": "11.1.1",
+        "@polkadot/types-create": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/util-crypto": "^12.6.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/types-augment": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-11.1.1.tgz",
+      "integrity": "sha512-aBfM+vu76YIym8Dvy00FJZRVz9cHqeghlTj3Lj1WjolVc+GuFxAWDx87p778Sb9d+iebA3pVY0wXNF+ZlRNDtg==",
+      "requires": {
+        "@polkadot/types": "11.1.1",
+        "@polkadot/types-codec": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/types-codec": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-11.1.1.tgz",
+      "integrity": "sha512-YMLEwerOO17M++EUAnh0SQWcDQNZ/l2nGmbSSvLEUBZdjXdtfLQ8NFVZakH5ehNHD+X3t0NLOQJg0hOBlVIj4A==",
+      "requires": {
+        "@polkadot/util": "^12.6.2",
+        "@polkadot/x-bigint": "^12.6.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/types-create": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-11.1.1.tgz",
+      "integrity": "sha512-Ro/9lYyEhGYTFoIvFUvAzdJ+0Of/tVnqewtwV35iXX9C86GazE8URJPrHFh4J/GBLQY0/JiT++PwxwFNH/kJsw==",
+      "requires": {
+        "@polkadot/types-codec": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/types-known": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-11.1.1.tgz",
+      "integrity": "sha512-Kp+KrCIxy8FkfqzyV/KpRGJC8bBAK8eKC/ta7bCo++kmdGc9FFfpmTMPIYOtd8vxYdL71KA40bI9LqodCaopQg==",
+      "requires": {
+        "@polkadot/networks": "^12.6.2",
+        "@polkadot/types": "11.1.1",
+        "@polkadot/types-codec": "11.1.1",
+        "@polkadot/types-create": "11.1.1",
+        "@polkadot/util": "^12.6.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/types-support": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-11.1.1.tgz",
+      "integrity": "sha512-Wf1aYs5lEtwksFH8EBNZMxBJlcRFx/sewErzpwGJJFT8BGcrQpc6HlNjVXJpTdXj+0VzUBHE9B8eAWfWQl8YIA==",
+      "requires": {
+        "@polkadot/util": "^12.6.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/util": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-12.6.2.tgz",
+      "integrity": "sha512-l8TubR7CLEY47240uki0TQzFvtnxFIO7uI/0GoWzpYD/O62EIAMRsuY01N4DuwgKq2ZWD59WhzsLYmA5K6ksdw==",
+      "requires": {
+        "@polkadot/x-bigint": "12.6.2",
+        "@polkadot/x-global": "12.6.2",
+        "@polkadot/x-textdecoder": "12.6.2",
+        "@polkadot/x-textencoder": "12.6.2",
+        "@types/bn.js": "^5.1.5",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/util-crypto": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-12.6.2.tgz",
+      "integrity": "sha512-FEWI/dJ7wDMNN1WOzZAjQoIcCP/3vz3wvAp5QQm+lOrzOLj0iDmaIGIcBkz8HVm3ErfSe/uKP0KS4jgV/ib+Mg==",
+      "requires": {
+        "@noble/curves": "^1.3.0",
+        "@noble/hashes": "^1.3.3",
+        "@polkadot/networks": "12.6.2",
+        "@polkadot/util": "12.6.2",
+        "@polkadot/wasm-crypto": "^7.3.2",
+        "@polkadot/wasm-util": "^7.3.2",
+        "@polkadot/x-bigint": "12.6.2",
+        "@polkadot/x-randomvalues": "12.6.2",
+        "@scure/base": "^1.1.5",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@noble/curves": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
+          "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+          "requires": {
+            "@noble/hashes": "1.4.0"
+          }
+        },
+        "@noble/hashes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+          "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="
+        }
+      }
+    },
+    "@polkadot/wasm-bridge": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.3.2.tgz",
+      "integrity": "sha512-AJEXChcf/nKXd5Q/YLEV5dXQMle3UNT7jcXYmIffZAo/KI394a+/24PaISyQjoNC0fkzS1Q8T5pnGGHmXiVz2g==",
+      "requires": {
+        "@polkadot/wasm-util": "7.3.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/wasm-crypto": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.3.2.tgz",
+      "integrity": "sha512-+neIDLSJ6jjVXsjyZ5oLSv16oIpwp+PxFqTUaZdZDoA2EyFRQB8pP7+qLsMNk+WJuhuJ4qXil/7XiOnZYZ+wxw==",
+      "requires": {
+        "@polkadot/wasm-bridge": "7.3.2",
+        "@polkadot/wasm-crypto-asmjs": "7.3.2",
+        "@polkadot/wasm-crypto-init": "7.3.2",
+        "@polkadot/wasm-crypto-wasm": "7.3.2",
+        "@polkadot/wasm-util": "7.3.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/wasm-crypto-asmjs": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.3.2.tgz",
+      "integrity": "sha512-QP5eiUqUFur/2UoF2KKKYJcesc71fXhQFLT3D4ZjG28Mfk2ZPI0QNRUfpcxVQmIUpV5USHg4geCBNuCYsMm20Q==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/wasm-crypto-init": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.3.2.tgz",
+      "integrity": "sha512-FPq73zGmvZtnuJaFV44brze3Lkrki3b4PebxCy9Fplw8nTmisKo9Xxtfew08r0njyYh+uiJRAxPCXadkC9sc8g==",
+      "requires": {
+        "@polkadot/wasm-bridge": "7.3.2",
+        "@polkadot/wasm-crypto-asmjs": "7.3.2",
+        "@polkadot/wasm-crypto-wasm": "7.3.2",
+        "@polkadot/wasm-util": "7.3.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/wasm-crypto-wasm": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.3.2.tgz",
+      "integrity": "sha512-15wd0EMv9IXs5Abp1ZKpKKAVyZPhATIAHfKsyoWCEFDLSOA0/K0QGOxzrAlsrdUkiKZOq7uzSIgIDgW8okx2Mw==",
+      "requires": {
+        "@polkadot/wasm-util": "7.3.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/wasm-util": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.3.2.tgz",
+      "integrity": "sha512-bmD+Dxo1lTZyZNxbyPE380wd82QsX+43mgCm40boyKrRppXEyQmWT98v/Poc7chLuskYb6X8IQ6lvvK2bGR4Tg==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/x-bigint": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-12.6.2.tgz",
+      "integrity": "sha512-HSIk60uFPX4GOFZSnIF7VYJz7WZA7tpFJsne7SzxOooRwMTWEtw3fUpFy5cYYOeLh17/kHH1Y7SVcuxzVLc74Q==",
+      "requires": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/x-fetch": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-12.6.2.tgz",
+      "integrity": "sha512-8wM/Z9JJPWN1pzSpU7XxTI1ldj/AfC8hKioBlUahZ8gUiJaOF7K9XEFCrCDLis/A1BoOu7Ne6WMx/vsJJIbDWw==",
+      "requires": {
+        "@polkadot/x-global": "12.6.2",
+        "node-fetch": "^3.3.2",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+          "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+          "requires": {
+            "data-uri-to-buffer": "^4.0.0",
+            "fetch-blob": "^3.1.4",
+            "formdata-polyfill": "^4.0.10"
+          }
+        }
+      }
+    },
+    "@polkadot/x-global": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-12.6.2.tgz",
+      "integrity": "sha512-a8d6m+PW98jmsYDtAWp88qS4dl8DyqUBsd0S+WgyfSMtpEXu6v9nXDgPZgwF5xdDvXhm+P0ZfVkVTnIGrScb5g==",
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/x-randomvalues": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-12.6.2.tgz",
+      "integrity": "sha512-Vr8uG7rH2IcNJwtyf5ebdODMcr0XjoCpUbI91Zv6AlKVYOGKZlKLYJHIwpTaKKB+7KPWyQrk4Mlym/rS7v9feg==",
+      "requires": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/x-textdecoder": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-12.6.2.tgz",
+      "integrity": "sha512-M1Bir7tYvNappfpFWXOJcnxUhBUFWkUFIdJSyH0zs5LmFtFdbKAeiDXxSp2Swp5ddOZdZgPac294/o2TnQKN1w==",
+      "requires": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/x-textencoder": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-12.6.2.tgz",
+      "integrity": "sha512-4N+3UVCpI489tUJ6cv3uf0PjOHvgGp9Dl+SZRLgFGt9mvxnvpW/7+XBADRMtlG4xi5gaRK7bgl5bmY6OMDsNdw==",
+      "requires": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@polkadot/x-ws": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-12.6.2.tgz",
+      "integrity": "sha512-cGZWo7K5eRRQCRl2LrcyCYsrc3lRbTlixZh3AzgU8uX4wASVGRlNWi/Hf4TtHNe1ExCDmxabJzdIsABIfrr7xw==",
+      "requires": {
+        "@polkadot/x-global": "12.6.2",
+        "tslib": "^2.6.2",
+        "ws": "^8.15.1"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.17.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+          "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+          "requires": {}
+        }
+      }
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -4647,6 +5972,63 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "@scure/base": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.6.tgz",
+      "integrity": "sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g=="
+    },
+    "@substrate/connect": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.10.tgz",
+      "integrity": "sha512-DIyQ13DDlXqVFnLV+S6/JDgiGowVRRrh18kahieJxhgvzcWicw5eLc6jpfQ0moVVLBYkO7rctB5Wreldwpva8w==",
+      "optional": true,
+      "requires": {
+        "@substrate/connect-extension-protocol": "^2.0.0",
+        "@substrate/connect-known-chains": "^1.1.4",
+        "@substrate/light-client-extension-helpers": "^0.0.6",
+        "smoldot": "2.0.22"
+      }
+    },
+    "@substrate/connect-extension-protocol": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-2.0.0.tgz",
+      "integrity": "sha512-nKu8pDrE3LNCEgJjZe1iGXzaD6OSIDD4Xzz/yo4KO9mQ6LBvf49BVrt4qxBFGL6++NneLiWUZGoh+VSd4PyVIg==",
+      "optional": true
+    },
+    "@substrate/connect-known-chains": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@substrate/connect-known-chains/-/connect-known-chains-1.1.4.tgz",
+      "integrity": "sha512-iT+BdKqvKl/uBLd8BAJysFM1BaMZXRkaXBP2B7V7ob/EyNs5h0EMhTVbO6MJxV/IEOg5OKsyl6FUqQK7pKnqyw==",
+      "optional": true
+    },
+    "@substrate/light-client-extension-helpers": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@substrate/light-client-extension-helpers/-/light-client-extension-helpers-0.0.6.tgz",
+      "integrity": "sha512-girltEuxQ1BvkJWmc8JJlk4ZxnlGXc/wkLcNguhY+UoDEMBK0LsdtfzQKIfrIehi4QdeSBlFEFBoI4RqPmsZzA==",
+      "optional": true,
+      "requires": {
+        "@polkadot-api/json-rpc-provider": "0.0.1",
+        "@polkadot-api/json-rpc-provider-proxy": "0.0.1",
+        "@polkadot-api/observable-client": "0.1.0",
+        "@polkadot-api/substrate-client": "0.0.1",
+        "@substrate/connect-extension-protocol": "^2.0.0",
+        "@substrate/connect-known-chains": "^1.1.4",
+        "rxjs": "^7.8.1"
+      }
+    },
+    "@substrate/ss58-registry": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.48.0.tgz",
+      "integrity": "sha512-lE9TGgtd93fTEIoHhSdtvSFBoCsvTbqiCvQIMvX4m6BO/hESywzzTzTFMVP1doBwDDMAN4lsMfIM3X3pdmt7kQ=="
+    },
+    "@types/bn.js": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.5.tgz",
+      "integrity": "sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/json-schema": {
       "version": "7.0.15",
@@ -5098,11 +6480,15 @@
         "which": "^2.0.1"
       }
     },
+    "data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
+    },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       },
@@ -5110,8 +6496,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -5545,6 +6930,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5594,6 +6984,15 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
+      }
+    },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
       }
     },
     "file-entry-cache": {
@@ -5692,6 +7091,14 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
       }
     },
     "fraction.js": {
@@ -6216,6 +7623,11 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+    },
     "json5": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
@@ -6400,6 +7812,11 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
+    "mock-socket": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+      "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw=="
+    },
     "moment": {
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
@@ -6452,6 +7869,21 @@
         "near-abi": "0.1.1",
         "node-fetch": "2.6.7"
       }
+    },
+    "nock": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
+      "integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      }
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -6619,6 +8051,11 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag=="
+    },
     "protobufjs": {
       "version": "6.11.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
@@ -6746,6 +8183,14 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "safe-array-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
@@ -6773,6 +8218,12 @@
         "get-intrinsic": "^1.1.3",
         "is-regex": "^1.1.4"
       }
+    },
+    "scale-ts": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/scale-ts/-/scale-ts-1.6.0.tgz",
+      "integrity": "sha512-Ja5VCjNZR8TGKhUumy9clVVxcDpM+YFjAnkMuwQy68Hixio3VRRvWdE3g8T/yC+HXA0ZDQl2TGyUmtmbcVl40Q==",
+      "optional": true
     },
     "seedrandom": {
       "version": "3.0.5",
@@ -6844,6 +8295,24 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
+    },
+    "smoldot": {
+      "version": "2.0.22",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.22.tgz",
+      "integrity": "sha512-B50vRgTY6v3baYH6uCgL15tfaag5tcS2o/P5q1OiXcKGv1axZDfz2dzzMuIkVpyMR2ug11F6EAtQlmYBQd292g==",
+      "optional": true,
+      "requires": {
+        "ws": "^8.8.1"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.17.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+          "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+          "optional": true,
+          "requires": {}
+        }
+      }
     },
     "split-on-first": {
       "version": "1.1.0",
@@ -6982,6 +8451,11 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7085,6 +8559,11 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@cosmjs/cosmwasm-stargate": "^0.31.3",
     "@cosmjs/stargate": "^0.31.3",
     "@near-js/types": "^0.2.0",
+    "@polkadot/api": "^11.1.1",
     "chalk": "^4.0.0",
     "cosmjs-types": "^0.5.2",
     "fireblocks-sdk": "^4.0.0",

--- a/src/backend/local.ts
+++ b/src/backend/local.ts
@@ -11,6 +11,7 @@ import {
   type TransferPeerPathResponse,
   type PublicKeyInfoForVaultAccountArgs,
   type PublicKeyResponse,
+  type DepositAddressResponse,
   TransactionStatus,
   PeerType
 } from 'fireblocks-sdk'
@@ -132,6 +133,10 @@ export class LocalSignerBackend implements SignerBackend {
   }
 
   public async getPublicKeyInfoForVaultAccount (args: PublicKeyInfoForVaultAccountArgs): Promise<PublicKeyResponse> {
+    throw new Error('method not implemented')
+  }
+
+  public async getDepositAddresses (vaultAccountId: string, assetId: string): Promise<DepositAddressResponse[]> {
     throw new Error('method not implemented')
   }
 }

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -7,5 +7,11 @@ export enum SignerType {
 
 export enum NetworkType {
   COSMOS = 'cosmos',
-  NEAR = 'near'
+  NEAR = 'near',
+  SUBSTRATE = 'substrate'
+}
+
+export enum RewardDestination {
+  STASH = 'Stash',
+  CONTROLLER = 'Controller'
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { Command } from '@commander-js/extra-typings'
 import { makeCosmosCommand } from './cosmos/cmd'
 import { makeNearCommand } from './near/cmd'
+import { makeSubstrateCommand } from './substrate/cmd'
 
 const program = new Command()
 
@@ -16,7 +17,8 @@ program
   .version('1.0.0')
 
 program.addCommand(makeCosmosCommand())
-program.addCommand(makeNearCommand());
+program.addCommand(makeNearCommand())
+program.addCommand(makeSubstrateCommand());
 
 (async () => {
   await program.parseAsync()

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -109,4 +109,10 @@ export class Signer {
 
     return pubKeyResponse.publicKey
   }
+
+  async getDepositAddress (vaultAccountId: string, assetId: string): Promise<string> {
+    const response = await this.signerBackend.getDepositAddresses(vaultAccountId, assetId)
+
+    return response[0].address
+  }
 }

--- a/src/substrate/cmd.ts
+++ b/src/substrate/cmd.ts
@@ -1,0 +1,204 @@
+import { Command } from '@commander-js/extra-typings'
+import type { Config, SignerBackend, SubstrateNetworkConfig } from '../types'
+import { Signer } from '../signer'
+import type { SignerType } from '../enums'
+import { readConfig, getNetworkConfig, print } from '../util'
+import { newSignerBackend } from '../backend/backend'
+import { SubstrateStaker } from './staker'
+import type { ISubmittableResult } from '@polkadot/types/types'
+
+export function makeSubstrateCommand (): Command {
+  const substrate = new Command('substrate')
+
+  substrate.addCommand(makeTxCommand())
+
+  return substrate
+}
+
+function makeTxCommand (): Command {
+  const tx = new Command('tx')
+    .description('generate a signed transaction')
+    .option('-b, --broadcast', 'broadcast generated transaction', false)
+    .option('-j, --journal <value>', 'write TX\'es to the local journal log', 'true')
+
+  tx.command('delegate')
+    .description('generate a delegate funds to validator transaction')
+    .argument(
+      '<amount>',
+      'amount of tokens to stake expressed in DOT/KSM/etc denom e.g 0.1'
+    )
+    .action(getDelegateTx)
+
+  tx.command('bond-extra')
+    .description('delegate more tokens (use this if you delegated already) to validator')
+    .argument(
+      '<amount>',
+      'amount of tokens to stake expressed in DOT/KSM/etc denom e.g 0.1'
+    )
+    .action(getBondExtraTx)
+
+  tx.command('nominate')
+    .description('generate a nominate funds to validator transaction')
+    .action(getNominateTx)
+
+  tx.command('unbond')
+    .description('generate unbond funds to validator transaction')
+    .argument(
+      '<amount>',
+      'amount of tokens to stake expressed in denom e.g 0.1. Zero (0) to unstake all funds.'
+    )
+    .action(getUnbondTx)
+
+  tx.command('withdraw')
+    .description('withdraw all unstaked funds from the validator contract')
+    .action(getWithdrawTx)
+
+  return tx
+}
+
+async function init (
+  cmd: Command<[string]> | Command<[]>
+): Promise<
+  [Config, Signer]
+  > {
+  const path: string = cmd.parent?.parent?.parent?.getOptionValue('config') as string
+  const signerType: string = cmd.parent?.parent?.parent?.getOptionValue(
+    'signer'
+  ) as string
+
+  const config: Config = await readConfig(path).catch((e) => {
+    cmd.error(e, { exitCode: 1, code: 'delegate.config.fs' })
+  })
+
+  const signerBackend: SignerBackend = await newSignerBackend(config, signerType as SignerType)
+  const signer = new Signer(signerBackend)
+
+  return [config, signer]
+}
+
+async function runTx (
+  msgType: string,
+  options: any,
+  cmd: Command<[string]> | Command<[]>,
+  arg: string[]
+): Promise<Uint8Array> {
+  const broadcastEnabled = cmd.parent?.getOptionValue('broadcast') as boolean
+  const journalEnabled: boolean = JSON.parse(cmd.parent?.getOptionValue('journal') as string)
+
+  const [config, signerClient] = await init(cmd)
+
+  const substrateStaker: SubstrateStaker = new SubstrateStaker(signerClient, config, journalEnabled)
+  await substrateStaker.init()
+
+  let response: ISubmittableResult | undefined
+  let errMsg: string = ''
+
+  print(1, 3, 'prepare unsigned transaction')
+  console.log(JSON.stringify({
+    delegator: config.delegatorAddress,
+    contractId: config.validatorAddress,
+    messageType: msgType,
+    args: arg,
+    broadcast: broadcastEnabled
+  }, null, 2))
+
+  try {
+    switch (msgType) {
+      case 'delegate':
+        [response, errMsg] = await substrateStaker.delegate(
+          arg[0], // amount
+          broadcastEnabled
+        )
+        break
+      case 'bondExtra':
+        [response, errMsg] = await substrateStaker.bondExtra(
+          arg[0], // amount
+          broadcastEnabled
+        )
+        break
+      case 'nominate':
+        [response, errMsg] = await substrateStaker.nominate(
+          broadcastEnabled
+        )
+        break
+      case 'undelegate':
+        [response, errMsg] = await substrateStaker.undelegate(
+          arg[0], // amount
+          broadcastEnabled
+        )
+        break
+      case 'withdraw':
+        [response, errMsg] = await substrateStaker.withdraw(
+          broadcastEnabled
+        )
+        break
+    }
+  } catch (e) {
+    cmd.error(e, { exitCode: 1, code: msgType + '.tx.sign' })
+  }
+
+  if (response === undefined) {
+    throw new Error('tx response is empty')
+  }
+
+  print(3, 3, 'inspect transaction outcome')
+  if (response.status.isInBlock) {
+    console.log(`transaction included at blockHash ${response.status.asInBlock.toString()}`)
+  }
+
+  if (response.status.isInBlock) {
+    console.log(`transaction finalized at blockHash ${response.status.asFinalized.toString()}`)
+  }
+
+  if (errMsg !== '') {
+    console.log(errMsg)
+  }
+
+  const networkConfig = getNetworkConfig<SubstrateNetworkConfig>(config)
+  if (networkConfig.blockExplorerUrl !== undefined) {
+    console.log(
+      '\nFind TX manually here: ' +
+          networkConfig.blockExplorerUrl + '/' + config.delegatorAddress
+    )
+  }
+
+  return Uint8Array.from([])
+}
+
+async function getDelegateTx (
+  amount: string,
+  options: any,
+  cmd: Command<[string]>
+): Promise<void> {
+  await runTx('delegate', options, cmd, [amount])
+}
+
+async function getBondExtraTx (
+  amount: string,
+  options: any,
+  cmd: Command<[string]>
+): Promise<void> {
+  await runTx('bondExtra', options, cmd, [amount])
+}
+
+async function getNominateTx (
+  options: any,
+  cmd: Command<[]>
+): Promise<void> {
+  await runTx('nominate', options, cmd, [])
+}
+
+async function getUnbondTx (
+  amount: string,
+  options: any,
+  cmd: Command<[string]>
+): Promise<void> {
+  await runTx('undelegate', options, cmd, [amount])
+}
+
+async function getWithdrawTx (
+  options: any,
+  cmd: Command<[]>
+): Promise<void> {
+  await runTx('withdraw', options, cmd, [])
+}

--- a/src/substrate/signer.ts
+++ b/src/substrate/signer.ts
@@ -1,0 +1,66 @@
+import type { Signer as SubstrateSigner, SignerResult } from '@polkadot/api/types'
+import type { SignerPayloadRaw } from '@polkadot/types/types'
+import { blake2AsHex } from '@polkadot/util-crypto'
+import type { Signer } from '../signer'
+import type { Config } from '../types'
+import type { VaultAccountResponse } from 'fireblocks-sdk'
+
+export class SubstrateFireblocksSigner implements SubstrateSigner {
+  private readonly signer: Signer
+  private readonly config: Config
+  private vault: VaultAccountResponse
+  private note: string
+  private broadcast: boolean
+
+  constructor (config: Config, signer: Signer) {
+    this.signer = signer
+    this.config = config
+    this.broadcast = false
+  }
+
+  async init (): Promise<void> {
+    this.vault = await this.signer.getVault(this.config.fireblocks.vaultName)
+
+    const depositAddress = await this.signer.getDepositAddress(this.vault.id, this.config.fireblocks.assetId)
+    if (depositAddress !== this.config.delegatorAddress) {
+      throw new Error('the deposit address (from fireblocks) does not match the delegator address')
+    }
+  }
+
+  /**
+   * @description signs a raw payload, only the bytes data as supplied
+   */
+  async signRaw ({ data, type }: SignerPayloadRaw): Promise<SignerResult> {
+    data = (data.length > (256 + 1) * 2) ? blake2AsHex(data) : data
+
+    const txInfo = await this.signer.sign(
+      this.vault,
+      this.config.fireblocks.assetId,
+      this.config.delegatorAddress,
+      data.substring(2),
+      this.note
+    )
+
+    if (txInfo.signedMessages === undefined || txInfo.signedMessages?.length === 0) {
+      throw new Error("fireblocks didn't return any signed message, but it should")
+    }
+
+    if (!this.broadcast) {
+      console.log(txInfo.signedMessages[0])
+      throw new Error('broadcast is not enabled but the transaction was signed correctly')
+    }
+
+    const signature = '0x00' + txInfo.signedMessages[0].signature.fullSig
+
+    // @ts-expect-error from typcast
+    return { id: 1, signature }
+  }
+
+  setBroadcast (broadcast: boolean): void {
+    this.broadcast = broadcast
+  }
+
+  setNote (note: string): void {
+    this.note = note
+  }
+}

--- a/src/substrate/staker.ts
+++ b/src/substrate/staker.ts
@@ -1,0 +1,157 @@
+import type { SignerOptions } from '@polkadot/api/submittable/types'
+import type { Signer } from '../signer'
+import type { ISubmittableResult } from '@polkadot/types/types'
+import { journal, getNetworkConfig } from '../util'
+import type { Config, SubstrateNetworkConfig } from '../types'
+import { SubstrateFireblocksSigner } from './signer'
+import { ApiPromise, WsProvider } from '@polkadot/api'
+import { assert } from '@polkadot/util'
+
+export class SubstrateStaker {
+  private readonly signer: Signer
+  private readonly config: Config
+  private readonly withJournal: boolean
+  private readonly networkConfig: SubstrateNetworkConfig
+
+  private substrateSigner: SubstrateFireblocksSigner
+
+  constructor (signer: Signer, config: Config, withJournal: boolean) {
+    this.signer = signer
+    this.config = config
+    this.withJournal = withJournal
+    this.networkConfig = getNetworkConfig<SubstrateNetworkConfig>(config)
+  }
+
+  async init (): Promise<void> {
+    this.substrateSigner = new SubstrateFireblocksSigner(this.config, this.signer)
+    await this.substrateSigner.init()
+  }
+
+  @journal('delegate')
+  async delegate (amount: string, broadcast: boolean): Promise<[ISubmittableResult, string]> {
+    this.substrateSigner.setNote('delegate' + amount + ' to ' + this.config.delegatorAddress)
+    this.substrateSigner.setBroadcast(broadcast)
+
+    return await this.sendTransaction(
+      this.config.delegatorAddress,
+      { section: 'staking', method: 'bond' },
+      0,
+      [
+        (Number(amount) * this.networkConfig.denomMultiplier).toString(),
+        this.networkConfig.rewardDestination
+      ]
+    )
+  }
+
+  // nominate bonded amount to given validators
+  @journal('nominate')
+  async nominate (broadcast: boolean): Promise<[ISubmittableResult, string]> {
+    this.substrateSigner.setNote('nominate bonded amount to ' + this.config.delegatorAddress)
+    this.substrateSigner.setBroadcast(broadcast)
+
+    return await this.sendTransaction(
+      this.config.delegatorAddress,
+      { section: 'staking', method: 'nominate' },
+      0,
+      [
+        this.config.validatorAddress.split(',')
+      ]
+    )
+  }
+
+  @journal('undelegate')
+  async undelegate (amount: string, broadcast: boolean): Promise<[ISubmittableResult, string]> {
+    this.substrateSigner.setNote('unstake ' + amount + ' from ' + this.config.delegatorAddress)
+    this.substrateSigner.setBroadcast(broadcast)
+
+    return await this.sendTransaction(
+      this.config.delegatorAddress,
+      { section: 'staking', method: 'unbond' },
+      0,
+      [
+        (Number(amount) * this.networkConfig.denomMultiplier).toString()
+      ]
+    )
+  }
+
+  @journal('withdraw')
+  async withdraw (broadcast: boolean): Promise<[ISubmittableResult, string]> {
+    this.substrateSigner.setNote('withdraw all from ' + this.config.delegatorAddress)
+    this.substrateSigner.setBroadcast(broadcast)
+
+    return await this.sendTransaction(
+      this.config.delegatorAddress,
+      { section: 'staking', method: 'withdrawUnbonded' },
+      0,
+      []
+    )
+  }
+
+  @journal('bondExtra')
+  async bondExtra (amount: string, broadcast: boolean): Promise<[ISubmittableResult, string]> {
+    this.substrateSigner.setNote('bond extra ' + amount + ' to ' + this.config.delegatorAddress)
+    this.substrateSigner.setBroadcast(broadcast)
+
+    return await this.sendTransaction(
+      this.config.delegatorAddress,
+      { section: 'staking', method: 'bondExtra' },
+      0,
+      [
+        (Number(amount) * this.networkConfig.denomMultiplier).toString()
+      ]
+    )
+  }
+
+  async sendTransaction (
+    account: string,
+    txCall: { section: string, method: string },
+    blocks: number | undefined,
+    params: any[]
+  ): Promise<[ISubmittableResult, string]> {
+    const provider = new WsProvider(this.networkConfig.rpcUrl)
+    const api = await ApiPromise.create({ provider, noInitWarn: true })
+
+    assert(txCall.section in api.tx && txCall.method in api.tx[txCall.section], `unable to find method ${txCall.section}.${txCall.method}`)
+
+    const options: Partial<SignerOptions> = { signer: this.substrateSigner }
+
+    if (blocks === 0) {
+      // forever living extrinsic
+      options.era = 0
+    } else if (blocks !== undefined) {
+      const signedBlock = await api.rpc.chain.getBlock()
+      options.blockHash = signedBlock.block.header.hash
+
+      options.era = api.createType('ExtrinsicEra', {
+        current: signedBlock.block.header.number,
+        period: blocks
+      })
+    }
+
+    const result = api.tx[txCall.section][txCall.method](...params)
+    let ret: ISubmittableResult | undefined
+    let errMsg: string = ''
+
+    const unsub = await result.signAndSend(account, options, async (response) => {
+      ret = response
+
+      if (response.dispatchError !== undefined && response.dispatchError.isModule) {
+        const decoded = api.registry.findMetaError(response.dispatchError.asModule)
+        const { docs, name, section } = decoded
+
+        errMsg = `the transaction is submitted to the blockchain but failed, error: ${section}.${name}: ${docs.join(' ')}`
+        await provider.disconnect()
+      } else {
+        if (response.status.isInBlock) {
+          await provider.disconnect()
+        } else if (response.status.isFinalized) {
+          unsub()
+        }
+      }
+    })
+
+    assert(ret !== undefined, "transaction didn't return any result")
+
+    return [ret, errMsg]
+  }
+}

--- a/src/substrate/staker.ts
+++ b/src/substrate/staker.ts
@@ -83,7 +83,7 @@ export class SubstrateStaker {
       this.config.delegatorAddress,
       { section: 'staking', method: 'withdrawUnbonded' },
       0,
-      []
+      [null/* slashing spans */]
     )
   }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,15 +1,16 @@
-import {
-  type PagedVaultAccountsRequestFilters,
-  type PagedVaultAccountsResponse,
-  type TransactionArguments,
-  type RequestOptions,
-  type CreateTransactionResponse,
-  type TransactionResponse,
-  type PublicKeyInfoForVaultAccountArgs,
-  type PublicKeyResponse
+import type {
+  PagedVaultAccountsRequestFilters,
+  PagedVaultAccountsResponse,
+  TransactionArguments,
+  RequestOptions,
+  CreateTransactionResponse,
+  TransactionResponse,
+  PublicKeyInfoForVaultAccountArgs,
+  PublicKeyResponse,
+  DepositAddressResponse
 } from 'fireblocks-sdk'
 
-import { type NetworkType } from './enums'
+import type { NetworkType, RewardDestination } from './enums'
 
 export interface Config {
   // define validator address to interact with (delegate, undelegate etc)
@@ -30,6 +31,7 @@ export interface Config {
   // network specific configuration
   cosmos?: CosmosNetworkConfig
   near?: NearNetworkConfig
+  substrate?: SubstrateNetworkConfig
 }
 
 export interface FireblocksConfig {
@@ -81,6 +83,24 @@ export interface CosmosNetworkConfig {
   blockExplorerUrl?: string
 }
 
+export interface SubstrateNetworkConfig {
+  // e.g. wss://rpc.polkadot.io
+  rpcUrl: string
+
+  // block explorer URL to display Transaction ID via Web UI. Example:
+  // * https://westend.subscan.io/account
+  blockExplorerUrl: string
+
+  // the input amount of tokens is multiplied by this value to get the amount
+  // in the smallest unit of the token. e.g.
+  //  * 1000000000000 for testnet
+  //  * 10000000000 for mainnet
+  denomMultiplier: number
+
+  // Stash or Controller (likely u want Stash)
+  rewardDestination: RewardDestination
+}
+
 export interface LocalSigner {
   // a file containing delegator mnemonic
   mnemonicPath: string
@@ -99,6 +119,8 @@ export interface SignerBackend {
   getTransactionById: (txId: string) => Promise<TransactionResponse>
 
   getPublicKeyInfoForVaultAccount: (args: PublicKeyInfoForVaultAccountArgs) => Promise<PublicKeyResponse>
+
+  getDepositAddresses: (vaultAccountId: string, assetId: string) => Promise<DepositAddressResponse[]>
 }
 
 export interface Journal {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 import * as readline from 'readline'
+import * as process from 'process'
 import chalk from 'chalk'
 import { promises as fsPromises } from 'fs'
 import { type Journal, type JournalEntry, type Config } from './types'
@@ -119,4 +120,16 @@ export async function prompt (ask: string): Promise<boolean> {
 
 export function print (step: number, total: number, msg: string): void {
   console.log(chalk.green(`# [${step}/${total}] ${msg}`))
+}
+
+export function checkNodeVersion (versionPrefix: string, err?: string): void {
+  const version = process.version
+  if (version.startsWith(versionPrefix)) {
+    if (err !== undefined) {
+      console.error(err)
+    } else {
+      console.error(`Error: Node.js version ${version} is not supported.`)
+    }
+    process.exit(1)
+  }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -82,6 +82,11 @@ export function getNetworkConfig<T> (cfg: Config): T {
         throw new Error('cosmos configuration is missing')
       }
       return cfg.cosmos as T
+    case NetworkType.SUBSTRATE:
+      if (cfg.substrate === undefined) {
+        throw new Error('substrate configuration is missing')
+      }
+      return cfg.substrate as T
   }
 }
 


### PR DESCRIPTION
# TL;DR
With this PR one can stake, unstake, nominate funds with substrate networks. This is tested with Polkadot testnet only, but technically should work well with kusama etc.

# Test Plan
```
# bond
$ npm run fireblocks-staking -- substrate tx bond 0.0001 -c ./config.polkadot.json -b
https://westend.subscan.io/extrinsic/20935533-2

# bond extra
$ npm run fireblocks-staking -- substrate tx bond 0.0001 -c ./config.polkadot.json -b
https://westend.subscan.io/extrinsic/21006113-2

# nominate stake
$ npm run fireblocks-staking -- substrate tx nominate -c ./config.polkadot.json -b
https://westend.subscan.io/extrinsic/21006118-2

# unbond
$ npm run fireblocks-staking -- substrate tx unbond 0.1 -c ./config.polkadot.json -b
https://westend.subscan.io/extrinsic/21006263-2

# withdraw unbonded
npm run fireblocks-staking -- substrate tx withdraw  -c ./config.polkadot.json -b
https://westend.subscan.io/extrinsic/21006397-2
```


config used:
```
{
    "validatorAddress": "5CAsa5uG1i3Duq5NM1g8zYjNvUCwkwADxgFQiypSLTg6Hnwm",
    "delegatorAddress": "5CsM7oXZQmDvrskYZHeLxTwERikgZDCZL6rkNryPmhpD8FwN",

    "fireblocks": {
        "apiSecretKeyPath": "./fireblocks_secret_key",
        "apiKeyPath": "./fireblocks_api_key",

        "vaultName": "dydx-test-wallet",
        "assetId": "WND"
    },

    "localsigner": {
        "mnemonicPath": "./mnemonic"
    },

    "networkType": "substrate",

    "substrate": {
        "rpcUrl": "wss://westend.public.curie.radiumblock.co/ws",
        "denomMultiplier": 1000000000000,
        "rewardDestination": "Stash",
        "blockExplorerUrl": "https://westend.subscan.io/account"
    }
}
```